### PR TITLE
feat(navbar): add new item for ext-link to volunteer form

### DIFF
--- a/components/core/header/nav-bar/NavBar.i18n.js
+++ b/components/core/header/nav-bar/NavBar.i18n.js
@@ -26,6 +26,7 @@ export default genI18nMessages({
         financialAid: 'Financial Aid',
         venue: 'Venue',
         covid19Guidelines: 'COVID-19 Guidelines',
+        volunteer: 'Volunteer',
     },
     'zh-hant': {
         about: '關於',
@@ -52,5 +53,6 @@ export default genI18nMessages({
         financialAid: '財務補助',
         venue: '會場',
         covid19Guidelines: 'COVID-19 防疫守則',
+        volunteer: '志工招募',
     },
 })

--- a/components/core/header/nav-bar/NavBar.vue
+++ b/components/core/header/nav-bar/NavBar.vue
@@ -44,13 +44,19 @@
             {{ $t('covid19Guidelines') }}
         </locale-link>
         -->
+        <ext-link
+            href="https://forms.gle/wuG2w42cbhamyGdv9"
+            :class="getPageClassesByPath('volunteer', true)"
+        >
+            {{ $t('volunteer') }}
+        </ext-link>
     </nav>
 </template>
 
 <script>
 import NavBarItemDropdown from './NavBarItemDropdown'
 import i18n from './NavBar.i18n'
-import { LocaleLink } from '~/components/core/links'
+import { LocaleLink, ExtLink } from '~/components/core/links'
 
 export default {
     i18n,
@@ -58,6 +64,7 @@ export default {
     components: {
         NavBarItemDropdown,
         LocaleLink,
+        ExtLink,
     },
     computed: {
         conferenceItems() {

--- a/i18n/index.i18n.js
+++ b/i18n/index.i18n.js
@@ -3,8 +3,12 @@ import { genI18nMessages } from '@/utils/i18n.utils'
 export default genI18nMessages({
     'en-us': {
         pyconWelcome: 'Welcome to PyCon TW 2021',
+        sponsor: 'Sponsor Us',
+        volunteer: 'Join as Volunteer',
     },
     'zh-hant': {
         pyconWelcome: '歡迎來到 PyCon TW 2021',
+        sponsor: '贊助我們',
+        volunteer: '成為志工',
     },
 })

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -3,6 +3,18 @@
         <div class="container">
             <div>
                 <h1 class="text-6xl">{{ $t('pyconWelcome') }}</h1>
+                <div class="flex mt-8">
+                    <p class="rounded-button text-2xl px-12 py-2 mr-4">
+                        <locale-link to="sponsor">{{
+                            $t('sponsor')
+                        }}</locale-link>
+                    </p>
+                    <p class="rounded-button text-2xl px-12 py-2 mr-4">
+                        <ext-link href="https://forms.gle/wuG2w42cbhamyGdv9">{{
+                            $t('volunteer')
+                        }}</ext-link>
+                    </p>
+                </div>
             </div>
         </div>
         <!--        <h3>sponsor list</h3>-->
@@ -35,10 +47,15 @@
 <script>
 // import { mapState } from 'vuex'
 import i18n from '@/i18n/index.i18n'
+import { LocaleLink, ExtLink } from '~/components/core/links'
 
 export default {
     i18n,
     name: 'PageIndex',
+    components: {
+        LocaleLink,
+        ExtLink,
+    },
     // fetchOnServer: false,
     // computed: {
     //     ...mapState(['sponsorsData']),
@@ -97,5 +114,17 @@ export default {
 
 .links {
     padding-top: 15px;
+}
+
+.rounded-button {
+    border-radius: 30px;
+    border: 3px solid #212121;
+    color: #212121;
+}
+
+.rounded-button:hover {
+    border-radius: 30px;
+    border: 3px solid #526488;
+    color: #526488;
 }
 </style>


### PR DESCRIPTION
## Types of Changes


- [ ] **Bugfix**
- [x] **New feature**
- [ ] **Refactoring**
- [ ] **Breaking change** (any change that would cause existing functionality to not work as expected)
- [ ] **Documentation Update**
- [ ] **Other (please describe)**

## Description

Add Links to the volunteer form

## Steps to Test This Pull Request

1. Two buttons are added on the index page. One for the sponsor page & one for the volunteer form.
2. A new navbar item named `volunteer` is added and links to the volunteer form.

![image](https://user-images.githubusercontent.com/24987826/111731203-ed7c5400-88ad-11eb-816e-a5d803484a59.png)

