### PR TITLE
fix(favicon): correct favicon link

### DIFF
--- a/components/core/header/HomeIcon.vue
+++ b/components/core/header/HomeIcon.vue
@@ -1,6 +1,6 @@
 <template>
     <locale-link to="/" class="w-10">
-        <img src="/2021/snake-icon.svg" />
+        <img src="/snake-icon.svg" />
     </locale-link>
 </template>
 

--- a/docker-compose-dev.yml
+++ b/docker-compose-dev.yml
@@ -19,7 +19,7 @@ services:
       - ./node_modules:/app/node_modules:delegated
     environment: 
       - BUILD_TARGET=server
-      - ROUTER_BASE=/
+      - ROUTER_BASE=/2021/
       - HOST=0.0.0.0
       - BASE_URL=http://mock-server:9876
       - API_URL_BROWSER=http://0.0.0.0:9876

--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -22,7 +22,9 @@ export default {
             },
             { hid: 'description', name: 'description', content: '' },
         ],
-        link: [{ rel: 'icon', type: 'image/x-icon', href: '/favicon.ico' }],
+        link: [
+            { rel: 'icon', type: 'image/x-icon', href: '/2021/favicon.ico' },
+        ],
     },
 
     // Global CSS (https://go.nuxtjs.dev/config-css)


### PR DESCRIPTION
## Types of Changes

- [x] **Bugfix**
- [ ] **New feature**
- [ ] **Refactoring**
- [ ] **Breaking change** (any change that would cause existing functionality to not work as expected)
- [ ] **Documentation Update**
- [ ] **Other (please describe)**

## Description

- The current website fails to display the favicon after adding the router base in #23. Should add the route base in the favicon link.
- The router base `/2021` is also added to dev env for consistency with production env.