### PR TITLE
fix(static): correct the url of images in static folder

### DIFF
--- a/components/core/header/HomeIcon.vue
+++ b/components/core/header/HomeIcon.vue
@@ -4,7 +4,7 @@
         class="md:px-12 py-2 flex justify-center items-center bg-golden-primary"
         customized
     >
-        <img src="/snake-icon.svg" class="w-8" />
+        <img src="~/static/snake-icon.svg" class="w-8" />
         <span class="font-bold"> PyConTW </span>
     </locale-link>
 </template>

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -14,7 +14,7 @@
                 }}</text-button>
             </div>
             <div class="page-homeLandingFocus__image mx-12 md:mx-0">
-                <img src="/key-vision-logo.png" alt="" />
+                <img src="~/static/key-vision-logo.png" alt="" />
             </div>
             <div
                 class="page-homeLandingFocus__context flex flex-col text-golden text-center md:text-left mb-4 ml-0 md:mb-0 md:ml-8"
@@ -99,7 +99,7 @@ export default {
     width: 100vw;
     height: calc(100vh - 48px);
     content: '';
-    background-image: url('/page-home-background.png');
+    background-image: url('~@/static/page-home-background.png');
     background-position: center center;
     background-size: cover;
 }


### PR DESCRIPTION
## Types of Changes

- [x] **Bugfix**
- [ ] **New feature**
- [ ] **Refactoring**
- [ ] **Breaking change** (any change that would cause existing functionality to not work as expected)
- [ ] **Documentation Update**
- [ ] **Other (please describe)**

## Description

The relative path of `static` folder is added to the url of static images since the changes in #25 don't work and still cannot get the correct URLs. (Based on the [doc](https://nuxtjs.org/docs/2.x/directory-structure/static/#static-assets), if the router base is defined, the url is automatically handled by nuxt only when the `nuxt-link` is used.)
