### PR TITLE
feat(page): add url without year as canonical url

### DIFF
--- a/layouts/default.vue
+++ b/layouts/default.vue
@@ -18,6 +18,17 @@ export default {
         CoreFooter,
         AnnounceBar,
     },
+    head() {
+        return {
+            link: [
+                // add url without year prefix as canonical url
+                {
+                    rel: 'canonical',
+                    href: 'https://tw.pycon.org' + this.$route.path,
+                },
+            ],
+        }
+    },
 }
 </script>
 


### PR DESCRIPTION
## Types of Changes

- [ ] **Bugfix**
- [x] **New feature**
- [ ] **Refactoring**
- [ ] **Breaking change** (any change that would cause existing functionality to not work as expected)
- [ ] **Documentation Update**
- [ ] **Other (please describe)**

## Description

Add URL without year as canonical URL for better SEO.

e.g. the canonical URL of `https://tw.pycon.org/2021/en-us/sponsor/prospectus` is `https://tw.pycon.org/en-us/sponsor/prospectus`.
