### PR TITLE
fix: correct facebook fan page link

### DIFF
--- a/components/core/footer/Footer.vue
+++ b/components/core/footer/Footer.vue
@@ -27,7 +27,7 @@
                     :icon="['fab', 'blogger']"
                 />
                 <footer-icon
-                    href="https://www/facebook.com/pycontw"
+                    href="https://www.facebook.com/pycontw"
                     :icon="['fab', 'facebook']"
                 />
                 <footer-icon


### PR DESCRIPTION
## Types of Changes

- [x] **Bugfix**
- [ ] **New feature**
- [ ] **Refactoring**
- [ ] **Breaking change** (any change that would cause existing functionality to not work as expected)
- [ ] **Documentation Update**
- [ ] **Other (please describe)**

## Description

The link to Facebook fan page in the footer is wrong.