### PR TITLE
Add conference website links section in footer

### DIFF
--- a/components/core/footer/Footer.i18n.js
+++ b/components/core/footer/Footer.i18n.js
@@ -6,11 +6,13 @@ export default genI18nMessages({
         staff: 'Staff',
         community: 'Community',
         privacyPolicy: 'Privacy Policy',
+        history: 'History',
     },
     'zh-hant': {
         codeOfConduct: '行為準則',
         staff: '工作人員',
         community: '社群',
         privacyPolicy: '個人資料保護聲明',
+        history: '歷年網站',
     },
 })

--- a/components/core/footer/Footer.vue
+++ b/components/core/footer/Footer.vue
@@ -3,7 +3,7 @@
         class="w-full flex flex-col justify-between bg-dark-secondary text-golden"
     >
         <div class="w-full p-10">
-            <div class="h-32 flex justify-center">
+            <div class="h-24 flex justify-center">
                 <div class="flex flex-col items-center">
                     <locale-link to="/about/code-of-conduct" class="my-2">
                         {{ $t('codeOfConduct') }}
@@ -21,6 +21,7 @@
                     -->
                 </div>
             </div>
+            <footer-history />
             <div class="w-full flex justify-center items-center flex-wrap">
                 <footer-icon
                     href="https://pycontw.blogspot.tw/"
@@ -63,6 +64,7 @@
 <script>
 import i18n from './Footer.i18n'
 import FooterIcon from './FooterIcon'
+import FooterHistory from './FooterHistory'
 import { LocaleLink } from '~/components/core/links'
 
 export default {
@@ -71,6 +73,7 @@ export default {
     components: {
         FooterIcon,
         LocaleLink,
+        FooterHistory,
     },
 }
 </script>

--- a/components/core/footer/FooterHistory.vue
+++ b/components/core/footer/FooterHistory.vue
@@ -1,0 +1,92 @@
+<template>
+    <div class="mb-3">
+        <div class="flex justify-center cursor-default">
+            <p class="py-3 font-bold">{{ $t('history') }}</p>
+        </div>
+        <div
+            v-for="(count, index) in rowCount"
+            :key="`count_${index}`"
+            class="flex justify-center"
+        >
+            <ext-link
+                v-for="(history, insideIndex) in itemCountInRow(count)"
+                :key="`history_${insideIndex}`"
+                :href="history.link"
+                class="my-2 mx-3 font-semibold text-sm"
+                highlight
+                >{{ history.label }}</ext-link
+            >
+        </div>
+    </div>
+</template>
+
+<script>
+import ExtLink from '@/components/core/links/ExtLink'
+import i18n from './Footer.i18n'
+
+export default {
+    i18n,
+    name: 'CoreFooterHistory',
+    components: {
+        ExtLink,
+    },
+    data() {
+        return {
+            itemsPerRow: 3,
+            historiesArray: [
+                {
+                    label: '2012',
+                    link: 'https://tw.pycon.org/2012/',
+                },
+                {
+                    label: '2013',
+                    link: 'https://tw.pycon.org/2013/',
+                },
+                {
+                    label: '2014',
+                    link: 'https://tw.pycon.org/2014apac/',
+                },
+                {
+                    label: '2015',
+                    link: 'https://tw.pycon.org/2015apac/',
+                },
+                {
+                    label: '2016',
+                    link: 'https://tw.pycon.org/2016/',
+                },
+                {
+                    label: '2017',
+                    link: 'https://tw.pycon.org/2017/',
+                },
+                {
+                    label: '2018',
+                    link: 'https://tw.pycon.org/2018/',
+                },
+                {
+                    label: '2019',
+                    link: 'https://tw.pycon.org/2019/',
+                },
+                {
+                    label: '2020',
+                    link: 'https://tw.pycon.org/2020/',
+                },
+            ],
+        }
+    },
+    computed: {
+        rowCount() {
+            return Math.ceil(this.historiesArray.length / this.itemsPerRow)
+        },
+    },
+    methods: {
+        itemCountInRow(index) {
+            return this.historiesArray.slice(
+                (index - 1) * this.itemsPerRow,
+                index * this.itemsPerRow,
+            )
+        },
+    },
+}
+</script>
+
+<style scoped></style>

--- a/components/core/footer/FooterHistory.vue
+++ b/components/core/footer/FooterHistory.vue
@@ -1,5 +1,5 @@
 <template>
-    <div class="mb-3">
+    <div class="mt-10 mb-3">
         <div class="flex justify-center cursor-default">
             <p class="py-3 font-bold">{{ $t('history') }}</p>
         </div>

--- a/components/core/links/ExtLink.vue
+++ b/components/core/links/ExtLink.vue
@@ -40,7 +40,7 @@ a {
     color: inherit;
 }
 .highlight {
-    color: #9387ff;
+    color: #c2a53a;
 }
 .highlight:hover {
     color: #6656f8;

--- a/pages/about/index.vue
+++ b/pages/about/index.vue
@@ -70,17 +70,6 @@
         <i18n path="paragraph.year2020" tag="p"></i18n>
         <i18n path="paragraph.year2021" tag="p"></i18n>
         <i18n path="paragraph.outro" tag="p"></i18n>
-
-        <div class="flex flex-wrap w-full mt-32 mb-8 justify-center">
-            <ext-link
-                v-for="(history, i) in histories"
-                :key="`about_history_${i}`"
-                :href="history.link"
-                class="mx-4"
-                highlight
-                >{{ history.label }}</ext-link
-            >
-        </div>
     </i18n-page-wrapper>
 </template>
 
@@ -110,44 +99,6 @@ export default {
             linkPyConBlog2016:
                 'http://pycontw.blogspot.tw/2016/04/blog-post.html',
             linkPhotoAlbum: 'http://www.flickr.com/photos/pycon_tw/albums',
-            histories: [
-                {
-                    label: '2012',
-                    link: 'https://tw.pycon.org/2012/',
-                },
-                {
-                    label: '2013',
-                    link: 'https://tw.pycon.org/2013/',
-                },
-                {
-                    label: '2014',
-                    link: 'https://tw.pycon.org/2014apac/',
-                },
-                {
-                    label: '2015',
-                    link: 'https://tw.pycon.org/2015apac/',
-                },
-                {
-                    label: '2016',
-                    link: 'https://tw.pycon.org/2016/',
-                },
-                {
-                    label: '2017',
-                    link: 'https://tw.pycon.org/2017/',
-                },
-                {
-                    label: '2018',
-                    link: 'https://tw.pycon.org/2018/',
-                },
-                {
-                    label: '2019',
-                    link: 'https://tw.pycon.org/2019/',
-                },
-                {
-                    label: '2020',
-                    link: 'https://tw.pycon.org/2020/',
-                },
-            ],
         }
     },
 }


### PR DESCRIPTION
## Types of Changes

**Thanks for sending a pull request! Please fill in the following content to let us know better about this change.**
Please put an `x` in the box that applies.

- [ ] **Bugfix**
- [x] **New feature**
- [ ] **Refactoring**
- [ ] **Breaking change** (any change that would cause existing functionality to not work as expected)
- [ ] **Documentation Update**
- [ ] **Other (please describe)**

## Description

1. remove history website links [pages - about - index]
2. add history website links on footer [components - core - footer]
  - edit Footer.i18n.js
  - edit Footer.vue
  - add new file [FooterHistory.vue]
  - change footer.vue template class to "h-24" for more reasonable hight temporary
  - change ExtLink default color
## Steps to Test This Pull Request

Steps to reproduce the behavior:
1. Go to ' landing page '
2. switch en, zh to check footer


