### PR TITLE
fix(Dockerfile): correct BASE_URL & API_URL_BROWSER

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,10 +20,10 @@ COPY utils ./utils
 COPY nuxt.config.js .babelrc ./
 
 ENV ROUTER_BASE /2021/
-ENV BASE_URL http://pycontw-2021:8000
+ENV BASE_URL pycontw-2021:8000
 ENV BUILD_TARGET server
 ENV HOST 0.0.0.0
-ENV API_URL_BROWSER http://pycon.tw/prs
+ENV API_URL_BROWSER https://pycon.tw/prs
 
 RUN npm run build
 


### PR DESCRIPTION
## Types of Changes

- [x] **Bugfix**
- [ ] **New feature**
- [ ] **Refactoring**
- [ ] **Breaking change** (any change that would cause existing functionality to not work as expected)
- [ ] **Documentation Update**
- [ ] **Other (please describe)**

## Description

- API_URL_BROWSER only allow `https` as URL schema
- BASE_URL should be the path in docker network and schema is not needed