### PR TITLE
feat(index): add border radius for sponsor logo

### DIFF
--- a/components/sponsors/SponsorCard.vue
+++ b/components/sponsors/SponsorCard.vue
@@ -1,6 +1,6 @@
 <template>
     <div v-show="!!logoUrl" :class="classObject">
-        <img :src="logoUrl" alt="" class="object-contain w-full" />
+        <img :src="logoUrl" alt="" />
         <div v-if="!!tag" class="sponsorCard__tag">
             {{ tag }}
         </div>
@@ -29,6 +29,11 @@ export default {
 <style lang="postcss" scoped>
 .sponsorCard {
     @apply w-40 h-40 relative flex flex-col justify-center items-center bg-white rounded-2xl;
+}
+
+.sponsorCard > img {
+    @apply object-contain w-full;
+    border-radius: inherit;
 }
 
 .sponsorCard.-small {


### PR DESCRIPTION
## Types of Changes

- [ ] **Bugfix**
- [x] **New feature**
- [ ] **Refactoring**
- [ ] **Breaking change** (any change that would cause existing functionality to not work as expected)
- [ ] **Documentation Update**
- [ ] **Other (please describe)**

## Description

For the sponsor logo with colored background, the border on the card has inconsistent width, as shown below.

<img src="https://user-images.githubusercontent.com/24987826/116850893-05245780-ac24-11eb-8f55-fc848c742347.png" width="200px">

Thus, the border radius is also applied to the logo image.

<img src="https://user-images.githubusercontent.com/24987826/116850737-c1315280-ac23-11eb-9e35-acab71d62ea9.png" width="200px">
