### PR TITLE
feat: add COVID-19 Guidelines page

### DIFF
--- a/components/core/header/nav-bar/NavBar.vue
+++ b/components/core/header/nav-bar/NavBar.vue
@@ -55,6 +55,13 @@
         >
             {{ $t('volunteer') }}
         </ext-link>
+        <locale-link
+            to="/covid-19/guidelines"
+            :class="getPageClassesByPath('covid-19', true)"
+            customized
+        >
+            {{ $t('covid19Guidelines') }}
+        </locale-link>
         <ext-link
             :href="signInUrl"
             :class="getPageClassesByPath('signIn', true)"

--- a/components/core/header/nav-bar/NavBarHamburger.vue
+++ b/components/core/header/nav-bar/NavBarHamburger.vue
@@ -42,6 +42,12 @@
                 href="https://forms.gle/wuG2w42cbhamyGdv9"
                 >{{ $t('volunteer') }}</ext-link
             >
+            <locale-link
+                class="core-navBarHamburgerSlideInMenu__item"
+                to="/covid-19/guidelines"
+                customized
+                >{{ $t('covid19Guidelines') }}</locale-link
+            >
             <ext-link
                 class="core-navBarHamburgerSlideInMenu__item"
                 :href="signInUrl"

--- a/i18n/covid-19/index.i18n.js
+++ b/i18n/covid-19/index.i18n.js
@@ -1,0 +1,153 @@
+import { genI18nMessages } from '@/utils/i18n.utils'
+
+export default genI18nMessages({
+    'en-us': {
+        pageTitle: 'PyCon Taiwan COVID-19 Guidelines',
+        pageSummary:
+            'In response to the 2019 novel coronavirus (COVID-19) outbreak, ' +
+            'the PyCon TW host team (We) announced PyCon Taiwan COVID-19 Guidelines' +
+            'that are based on the COVID-19 prevention guidelines from Taiwan Central Epidemic Command Center (CECC).' +
+            'During the COVID-19 outbreak, these guidelines must be followed so as to prevent epidemic transmission and protect oneself and others.' +
+            'The guidelines will adopt any changes required by CECC without further notifications.' +
+            'Please pay attention to our website in particular to relevant modifications.' +
+            'The final guideline will be announced on August 1st, 2021.',
+        latestEditedTime: ['(CC BY-SA 3.0 TW)', 'Last Updated：2021-04-22'],
+        guidelinesTitle: 'Epidemic Prevention Guidelines',
+        guidelinesSummary:
+            'Every PyCon TW attendee has to fill out the {form} online,' +
+            'a personal QR code will be generated after you complete the form.' +
+            'Your QR code is your entry to PyCon TW 2021, it is not retrievable after it is lost.' +
+            'If you lose your QR code, you will need to fill out the Health Declaration Form again to obtain a new one.',
+        guidelinesSummaryList: [
+            'PyCon TW 2021 Health Declaration Form will be available online for previewing on August 20 and be ready for use on August 30.',
+            'If you are unable to fill out the form online, PyCon TW will provide the form on paper, please fill it out and give it to the staff at the venue.',
+        ],
+        guidelinesContent: [
+            'According to Taiwan Central Epidemic Command Center (CECC) COVID-19 Prevention Guidance, " To avoid close contact, all people should keep a distance from others of at least 1.5 meters in the indoor environment and 1 meter in outdoor. When this social distancing is not able to be maintained, all people are urged to wear face masks. Therefore, all PyCon TW 2021 attendees are required to wear face masks all the time when in indoor environments.',
+            'PyCon TW will be a real-name registration. All attendees need to show the QR code (the proven completion of the Health Declaration) to receive a badge. We will check badges at each venue for entry, please complete the registration process and collect your badge at the registration desk before entering each venue. All attendees’ temperatures will be taken prior to the entry.',
+            'Capacity limits are set for each venue for your safety and comfort. There are staff on-site to control the total number of people in each venue, please follow the instructions from staff on site. Do not enter a venue that is full.',
+            'If you feel ill or have a high risk of infection (home isolation, home quarantine, self-monitoring). Please stay home, do not go to the PyCon TW venue.',
+        ],
+        selfPreparationTitle: 'Self-preparation for Preventing COVID-19',
+        selfPreparationContent: [
+            'To complete PyCon TW 2021 Personal Health Declaration Form online before joining PyCon TW 2021 activities.',
+            'Wear a face mask before entering indoor places. It is recommended that you have one or two spare face masks with you.',
+            'Wash hands frequently, using hand sanitizer, and keeping social distancing are also helpful.',
+            'To sanitize seats and tables your own when moving to different venues.',
+        ],
+        pyConPreparednessTitle:
+            'PyCon Taiwan Preparedness for preventing COVID-19',
+        pyConPreparednessContent: [
+            'PyCon TW helps cleaning and disinfecting venues before and after each conference day. We prepare bleach solutions to sanitize all venues and facilities within, including floors of each venue and hallways, door and window handle, light and other facilities switches, tables, seats, washstand, and stair handrail.',
+            'Infrared Ear/Forehead Thermometers are available at the conference desk for anyone that feels like measuring temperatures.',
+            'Alcohol sanitizers are available for use at the conference desk.',
+        ],
+        privacyPoliceTitle: 'Privacy Policy of PyCon Taiwan',
+        privacyPolicyContent:
+            'PyCon TW 2021 collects personal data of attendees for the purpose of contact tracing during the outbreak of COVID-19. All collected information will be deleted after 28 days. attendees’ access in each venue will be recorded for epidemic control measures. We will inform everyone that if any suspected COVID-19 and provide such information for CECC for the purpose of preventing the spread of COVID-19 and tracing contacts. For more details please visit：{policy} (need update).',
+        governmentDocumentsTitle: 'Government Documents',
+        governmentDocumentsContent: [
+            {
+                title: '衛生福利部疾病管制署-嚴重急性呼吸道症候群防治工作手冊',
+                link: 'https://www.cdc.gov.tw/File/Get/s8bfTZsDHo4V2CE2-ozrDg',
+            },
+            {
+                title:
+                    '教育部函「防疫新生活運動」室內外集會須配合中央疫情指揮中心發布之相關指引',
+                link:
+                    'https://drive.google.com/file/d/1GA1U8GxqohUkB9nHaG1UhGXlU2Il37-5/view',
+            },
+            {
+                title: '國立臺灣大學嚴重特殊傳染性肺炎防治工作綱要',
+                link: 'https://my.ntu.edu.tw/ntuwdc/nasattach/messages/329.pdf',
+            },
+        ],
+        licenseTitle: 'License (CC BY-SA 3.0 TW)',
+        licenseContent: [
+            'This document is licensed under an Attribution-ShareAlike 3.0 Taiwan license.',
+            '{picSrc}',
+            'The Privacy Policy of PyCon Taiwan will be effective May 1st, 2021. However, due to the rapidly changing social and legal environment and the continual advancement in technology, we reserve the right to modify this privacy policy at any time and will announce any update when available.',
+            'Thank you.',
+        ],
+        otherLinks: {
+            form: 'PyCon TW 2021 Personal Health Declaration Form',
+            policy: 'Privacy Policy of PyCon Taiwan',
+            picSrc: 'https://i.imgur.com/cVjN760.jpg=200x',
+        },
+    },
+    'zh-hant': {
+        pageTitle: 'PyCon Taiwan COVID-19 防疫守則',
+        pageSummary:
+            '因應 2019 年新型冠狀病毒 (COVID-19) 疫情，' +
+            '「PyCon TW 主辦團隊」(以下簡稱「我們」) 參照我國中央流行疫情指揮中心的防疫措施，' +
+            '發布臺灣 Python 年會 (以下簡稱「PyCon TW」) 實體活動防疫守則。' +
+            '請您與我們一同遵守，保護自己與他人的健康。' +
+            '此防疫守則將視疫情發展與我國中央疫情疫情指揮中心指示有所變動，' +
+            '所有更動將不另通知，請在會前持續回來關心。' +
+            '最終版預計在 2021 年 08 月 01 日發布。',
+        latestEditedTime: ['(CC BY-SA 3.0 TW)', '最後更新時間：2021-04-22'],
+        guidelinesTitle: '防疫要點',
+        guidelinesSummary:
+            '每一位與會者須線上填寫 {form} (以下簡稱「個人健康申明書」)，' +
+            '填寫完畢個人健康聲明書可獲得專屬入場的 QR Code 與即能參與 PyCon TW 實體活動，' +
+            '該 QR Code 請務必妥善保管，' +
+            '因資料僅供儲存用，遺失將無法取回，' +
+            '僅能再度填寫個人健康聲明書領取新的 QR Code。',
+        guidelinesSummaryList: [
+            'PyCon TW 2021 個人健康聲明書預計於 2021 年 08 月 01 日開放檢視，並於 2021 年 08 月 30 日開放填寫。',
+            '若當日無法使用電子設備進行填寫者，PyCon TW 將提供紙本個人健康聲明書，請填妥後交由現場工作人員。',
+            '若對於個人健康申明書有疑慮者，歡迎向我們提出建議。',
+        ],
+        guidelinesContent: [
+            '配合我國中央流行疫情指揮中心的防疫措施：「保持社交距離（室內 1.5 公尺、室外 1 公尺），無法維持社交距離時，應配戴口罩」，與會者進入大會場地，請全程配戴口罩。',
+            'PyCon TW 會場進出採實名制，與會者須憑 QR Code 於報到處報到換取識別證，有識別證之參與者方可進入會場，工作人員將在各議程廳入口、PyNight (後台咖啡) 場地入口檢查與會者識別證，請務必先完成報到領取識別證後再行入場。所有與會者在入場前都要量測體溫。',
+            '各議程廳採人數總量管制，演講廳將有工作人員管控演講廳內部人數，請依照工作人員指示，若演講廳已達人數上限請勿進入。',
+            '若有身體不適或具感染風險 (居家隔離、居家檢疫、自主健康管理) 等情形者，請在家裡好好休息，請勿前往 PyCon TW 會場。',
+        ],
+        selfPreparationTitle: '參與者防疫準備',
+        selfPreparationContent: [
+            '務必填寫「PyCon TW 2021 個人健康聲明書」(中英文版填寫一份即可)。',
+            '配戴口罩：進入會議廳必須全程配戴口罩，可以隨身多備 1~2 枚口罩。',
+            '勤洗手，可搭配酒精消毒手部與座位。',
+            '議程移動時，請與會者自行消毒桌椅。',
+        ],
+        pyConPreparednessTitle: 'PyCon Taiwan 防疫準備',
+        pyConPreparednessContent: [
+            'PyCon Taiwan 活動前一天與第一天會議結束時，我們將以漂白水做全區域消毒，消毒範圍包含：室內與走廊地板、門把、窗戶把手、電器開關、桌椅、洗手臺、樓梯扶手。',
+            '大會報到處與服務台將備有額溫槍/耳溫槍，若有身體不適者，可前往量測。',
+            '大會報到處與服務台備有消毒用酒精，如有需要，可自行取用。',
+        ],
+        privacyPoliceTitle: '個人資料保護聲明',
+        privacyPolicyContent:
+            'PyCon TW 配合防疫期間所蒐集的資料，將在活動日起 28 天後刪除。參與者進出各館與各廳紀錄將作為疫情管控使用，若會後有任何疑似感染情況，PyCon TW 將主動通知可能被影響的群眾，且得提供我國衛生主管機關依傳染病防治法等規定進行疫情調查及聯繫使用。詳細聲明請參照：{policy}',
+        governmentDocumentsTitle: '政府機關公文',
+        governmentDocumentsContent: [
+            {
+                title: '衛生福利部疾病管制署-嚴重急性呼吸道症候群防治工作手冊',
+                link: 'https://www.cdc.gov.tw/File/Get/s8bfTZsDHo4V2CE2-ozrDg',
+            },
+            {
+                title:
+                    '教育部函「防疫新生活運動」室內外集會須配合中央疫情指揮中心發布之相關指引',
+                link:
+                    'https://drive.google.com/file/d/1GA1U8GxqohUkB9nHaG1UhGXlU2Il37-5/view',
+            },
+            {
+                title: '國立臺灣大學嚴重特殊傳染性肺炎防治工作綱要',
+                link: 'https://my.ntu.edu.tw/ntuwdc/nasattach/messages/329.pdf',
+            },
+        ],
+        licenseTitle: '授權 (CC BY-SA 3.0 TW)',
+        licenseContent: [
+            '此文件採用 姓名標示-相同方式分享 3.0 台灣 授權條款。',
+            '{picSrc}',
+            '本個人資料保護聲明從 2021 年 05 月 01 日起開始生效，惟為因應社會環境及法令的變遷與科技的進步，為保護客戶個人資料安全及隱私，我們將隨時修改這份公告聲明，並將儘速更新與公告予您。',
+            '感謝。',
+        ],
+        otherLinks: {
+            form: '「 PyCon TW 2021 個人健康聲明書 」',
+            policy: 'PyCon Taiwan 個人資料保護聲明。',
+            picSrc: 'https://i.imgur.com/cVjN760.jpg=200x',
+        },
+    },
+})

--- a/i18n/covid-19/index.i18n.js
+++ b/i18n/covid-19/index.i18n.js
@@ -64,7 +64,7 @@ export default genI18nMessages({
         ],
         licenseTitle: 'License (CC BY-SA 3.0 TW)',
         licenseContent: [
-            'This document is licensed under an Attribution-ShareAlike 3.0 Taiwan license.',
+            'This document is licensed under an {license} license.',
             '{picSrc}',
             'The Privacy Policy of PyCon Taiwan will be effective May 1st, 2021. However, due to the rapidly changing social and legal environment and the continual advancement in technology, we reserve the right to modify this privacy policy at any time and will announce any update when available.',
             'Thank you.',
@@ -73,6 +73,7 @@ export default genI18nMessages({
             form: 'PyCon TW 2021 Personal Health Declaration Form',
             policy: 'Privacy Policy of PyCon Taiwan',
             picSrc: 'https://i.imgur.com/cVjN760.jpg=200x',
+            license: 'Attribution-ShareAlike 3.0 Taiwan',
         },
     },
     'zh-hant': {
@@ -139,7 +140,7 @@ export default genI18nMessages({
         ],
         licenseTitle: '授權 (CC BY-SA 3.0 TW)',
         licenseContent: [
-            '此文件採用 姓名標示-相同方式分享 3.0 台灣 授權條款。',
+            '此文件採用 {license} 授權條款。',
             '{picSrc}',
             '本個人資料保護聲明從 2021 年 05 月 01 日起開始生效，惟為因應社會環境及法令的變遷與科技的進步，為保護客戶個人資料安全及隱私，我們將隨時修改這份公告聲明，並將儘速更新與公告予您。',
             '感謝。',
@@ -148,6 +149,7 @@ export default genI18nMessages({
             form: '「 PyCon TW 2021 個人健康聲明書 」',
             policy: 'PyCon Taiwan 個人資料保護聲明。',
             picSrc: 'https://i.imgur.com/cVjN760.jpg=200x',
+            license: '姓名標示-相同方式分享 3.0 台灣',
         },
     },
 })

--- a/pages/covid-19/guidelines.vue
+++ b/pages/covid-19/guidelines.vue
@@ -1,11 +1,156 @@
 <template>
-    <p>COVID 19 Guidelines</p>
+    <i18n-page-wrapper>
+        <core-h1 :title="$t('pageTitle')"></core-h1>
+        <i18n
+            v-for="(item, index) in $t('latestEditedTime')"
+            :key="`latestEditedTime_${index}`"
+            :path="`latestEditedTime.${index}`"
+            tag="p"
+            class="flex justify-center"
+        >
+        </i18n>
+        <core-hr></core-hr>
+        <i18n
+            path="pageSummary"
+            tag="p"
+            class="md:px-0 lg:px-36 xl:px-48"
+        ></i18n>
+        <core-hr></core-hr>
+        <i18n
+            path="guidelinesTitle"
+            tag="p"
+            class="flex justify-center section-title pt-10 pb-5"
+        ></i18n>
+        <div class="container">
+            <i18n
+                path="guidelinesSummary"
+                tag="p"
+                class="md:px-0 lg:px-30 xl:px-42"
+            >
+                <template #form>
+                    <ext-link href="https://cdc.pycon.tw/#/" highlight>{{
+                        $t('otherLinks.form')
+                    }}</ext-link>
+                </template>
+            </i18n>
+            <ul class="list-disc">
+                <li
+                    v-for="(item, index) in $t('guidelinesSummaryList')"
+                    :key="`guidelinesSummaryList_${index}`"
+                >
+                    {{ item }}
+                </li>
+            </ul>
+        </div>
+        <ol class="list-decimal md:px-0 lg:px-36 xl:px-48">
+            <li
+                v-for="(item, index) in $t('guidelinesContent')"
+                :key="`guidelinesContent_${index}`"
+            >
+                {{ item }}
+            </li>
+        </ol>
+        <i18n
+            path="selfPreparationTitle"
+            tag="p"
+            class="flex justify-center section-title pt-20 pb-5"
+        ></i18n>
+        <ol class="list-decimal md:px-0 lg:px-36 xl:px-48">
+            <li
+                v-for="(item, index) in $t('selfPreparationContent')"
+                :key="`selfPreparationContent_${index}`"
+            >
+                {{ item }}
+            </li>
+        </ol>
+        <i18n
+            path="pyConPreparednessTitle"
+            tag="p"
+            class="flex justify-center section-title pt-20 pb-5"
+        ></i18n>
+        <ol class="list-decimal md:px-0 lg:px-36 xl:px-48">
+            <li
+                v-for="(item, index) in $t('pyConPreparednessContent')"
+                :key="`pyConPreparednessContent_${index}`"
+            >
+                {{ item }}
+            </li>
+        </ol>
+        <i18n
+            path="privacyPoliceTitle"
+            tag="p"
+            class="flex justify-center section-title pt-20 pb-5"
+        ></i18n>
+        <ol class="list-decimal md:px-0 lg:px-36 xl:px-48">
+            <i18n path="privacyPolicyContent" tag="li">
+                <template #policy>
+                    <locale-link to="/about/privacy_policy/" highlight>{{
+                        $t('otherLinks.policy')
+                    }}</locale-link>
+                </template>
+            </i18n>
+        </ol>
+        <i18n
+            path="governmentDocumentsTitle"
+            tag="p"
+            class="flex justify-center section-title pt-20 pb-5"
+        ></i18n>
+        <ol class="list-decimal md:px-0 lg:px-36 xl:px-48">
+            <li
+                v-for="(item, index) in $t('governmentDocumentsContent')"
+                :key="`governmentDocumentsContent_${index}`"
+            >
+                <ext-link :href="item.link" highlight>{{
+                    item.title
+                }}</ext-link>
+            </li>
+        </ol>
+        <i18n
+            path="licenseTitle"
+            tag="p"
+            class="flex justify-center section-title pt-20 pb-5"
+        ></i18n>
+        <i18n
+            v-for="(item, index) in $t('licenseContent')"
+            :key="`licenseContent_${index}`"
+            :path="`licenseContent.${index}`"
+            tag="p"
+            class="md:px-0 lg:px-36 xl:px-48"
+        >
+            <template #picSrc>
+                <img :src="$t('otherLinks.picSrc')" highlight />
+            </template>
+        </i18n>
+    </i18n-page-wrapper>
 </template>
 
 <script>
+import I18nPageWrapper from '@/components/core/i18n/PageWrapper'
+import LocaleLink from '@/components/core/links/LocaleLink.vue'
+import ExtLink from '@/components/core/links/ExtLink.vue'
+import i18n from '@/i18n/covid-19/index.i18n'
+import CoreH1 from '@/components/core/titles/H1'
+import CoreHr from '@/components/core/layout/Hr.vue'
+
 export default {
+    i18n,
     name: 'PageCovid19Guidelines',
+    components: {
+        I18nPageWrapper,
+        CoreH1,
+        CoreHr,
+        ExtLink,
+        LocaleLink,
+    },
 }
 </script>
-
-<style scoped></style>
+<style scoped>
+.section-title {
+    color: #9387ff;
+}
+.container {
+    min-height: 0;
+    flex-direction: column;
+    text-align: left;
+}
+</style>

--- a/pages/covid-19/guidelines.vue
+++ b/pages/covid-19/guidelines.vue
@@ -84,7 +84,7 @@
         <ol class="list-decimal md:px-0 lg:px-36 xl:px-48">
             <i18n path="privacyPolicyContent" tag="li">
                 <template #policy>
-                    <locale-link to="/about/privacy_policy/" highlight>{{
+                    <locale-link to="/about/privacy-policy/" highlight>{{
                         $t('otherLinks.policy')
                     }}</locale-link>
                 </template>
@@ -119,6 +119,13 @@
         >
             <template #picSrc>
                 <img :src="$t('otherLinks.picSrc')" highlight />
+            </template>
+            <template #license>
+                <ext-link
+                    href="https://creativecommons.org/licenses/by-sa/3.0/tw/deed.zh_TW"
+                    highlight
+                    >{{ $t('otherLinks.license') }}</ext-link
+                >
             </template>
         </i18n>
     </i18n-page-wrapper>


### PR DESCRIPTION
## Types of Changes

**Thanks for sending a pull request! Please fill in the following content to let us know better about this change.**
Please put an `x` in the box that applies.

- [ ] **Bugfix**
- [x] **New feature**
- [ ] **Refactoring**
- [ ] **Breaking change** (any change that would cause existing functionality to not work as expected)
- [ ] **Documentation Update**
- [ ] **Other (please describe)**

## Description

1. Add Covid-19 Guidelines Pages
- add i18n/covid-19/index.i18n.js
- add pages/covid-19/guidelines.vue
- add local link components in NavBar.vue & NavBarHamburger.vue

## Steps to Test This Pull Request

1. Click On NavBar to visit Guidelines Page.

## Issue
1. There is no url for PyCon TW 2021 Personal Health Declaration Form, so use 2020 link for the moment.



