### PR TITLE
fix(Dockerfile): use tw.pycon.org as API URL

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,7 +23,7 @@ ENV ROUTER_BASE /2021/
 ENV BASE_URL pycontw-2021:8000
 ENV BUILD_TARGET server
 ENV HOST 0.0.0.0
-ENV API_URL_BROWSER https://pycon.tw/prs
+ENV API_URL_BROWSER https://tw.pycon.org/prs
 
 RUN npm run build
 


### PR DESCRIPTION
## Types of Changes

- [x] **Bugfix**
- [ ] **New feature**
- [ ] **Refactoring**
- [ ] **Breaking change** (any change that would cause existing functionality to not work as expected)
- [ ] **Documentation Update**
- [ ] **Other (please describe)**

## Description

The current `API_URL_BROWSER` is `pycon.tw` and the app is failed to send the request with `@nuxt/http`. Use redirect destination `tw.pycon.org` instead fixes this issue.