### PR TITLE
Fixed the click problem of homepage's sponsor link

### DIFF
--- a/components/core/buttons/TextButton.vue
+++ b/components/core/buttons/TextButton.vue
@@ -1,14 +1,9 @@
 <template>
-    <button>
-        <ext-link v-if="href" :href="href" :class="coreButtonClasses">
+    <button :class="coreButtonClasses">
+        <ext-link v-if="href" :href="href">
             <slot></slot>
         </ext-link>
-        <locale-link
-            v-else-if="to"
-            :to="to"
-            customized
-            :class="coreButtonClasses"
-        >
+        <locale-link v-else-if="to" :to="to" customized>
             <slot></slot>
         </locale-link>
         <slot v-else></slot>
@@ -50,6 +45,11 @@ export default {
             default: undefined,
         },
     },
+    data() {
+        return {
+            isLink: false,
+        }
+    },
     computed: {
         coreButtonClasses() {
             return {
@@ -58,7 +58,22 @@ export default {
                 '--secondary': this.secondary,
                 '--rounded': this.rounded,
                 '--block': this.block,
+                '--is-link': this.isLink,
             }
+        },
+    },
+    watch: {
+        isLink: {
+            immediate: true,
+            handler() {
+                if (this.href) {
+                    this.isLink = true
+                } else if (this.to) {
+                    this.isLink = true
+                } else {
+                    this.isLink = false
+                }
+            },
         },
     },
 }
@@ -66,6 +81,12 @@ export default {
 
 <style scoped>
 .core-button {
+    outline: none;
+    background-color: transparent;
+}
+
+.core-button:not(.--is-link),
+.core-button.--is-link > a {
     display: inline-flex;
     align-items: center;
     justify-content: center;
@@ -78,25 +99,28 @@ export default {
     outline: none;
     font-weight: 700;
     font-size: 1rem;
-    background-color: transparent;
 }
 
-.core-button.--rounded {
+.core-button:not(.--is-link):hover,
+.core-button.--is-link > a:hover {
+    color: #7568f6;
+    border-color: #7568f6;
+}
+
+.--rounded:not(.--is-link),
+.--rounded.--is-link > a {
     border-radius: 9999px;
 }
 
-.core-button.--primary {
+.--rounded:not(.--is-link),
+.--rounded.--is-link > a {
     color: #c2a53a;
     border: 0.25rem solid #c2a53a;
 }
 
-.core-button.--secondary {
+.--secondary:not(.--is-link),
+.--secondary.--is-link > a {
     color: #c7c7c7;
     border: 0.25rem solid #c7c7c7;
-}
-
-.core-button:hover {
-    color: #7568f6;
-    border-color: #7568f6;
 }
 </style>

--- a/components/core/buttons/TextButton.vue
+++ b/components/core/buttons/TextButton.vue
@@ -45,11 +45,6 @@ export default {
             default: undefined,
         },
     },
-    data() {
-        return {
-            isLink: false,
-        }
-    },
     computed: {
         coreButtonClasses() {
             return {
@@ -61,19 +56,8 @@ export default {
                 '--is-link': this.isLink,
             }
         },
-    },
-    watch: {
-        isLink: {
-            immediate: true,
-            handler() {
-                if (this.href) {
-                    this.isLink = true
-                } else if (this.to) {
-                    this.isLink = true
-                } else {
-                    this.isLink = false
-                }
-            },
+        isLink() {
+            return this.href || this.to
         },
     },
 }
@@ -101,26 +85,26 @@ export default {
     font-size: 1rem;
 }
 
-.core-button:not(.--is-link):hover,
-.core-button.--is-link > a:hover {
-    color: #7568f6;
-    border-color: #7568f6;
-}
-
-.--rounded:not(.--is-link),
-.--rounded.--is-link > a {
+.core-button.--rounded:not(.--is-link),
+.core-button.--rounded.--is-link > a {
     border-radius: 9999px;
 }
 
-.--rounded:not(.--is-link),
-.--rounded.--is-link > a {
+.core-button.--primary:not(.--is-link),
+.core-button.--primary.--is-link > a {
     color: #c2a53a;
     border: 0.25rem solid #c2a53a;
 }
 
-.--secondary:not(.--is-link),
-.--secondary.--is-link > a {
+.core-button.--secondary:not(.--is-link),
+.core-button.--secondary.--is-link > a {
     color: #c7c7c7;
     border: 0.25rem solid #c7c7c7;
+}
+
+.core-button:not(.--is-link):hover,
+.core-button.--is-link > a:hover {
+    color: #7568f6;
+    border-color: #7568f6;
 }
 </style>

--- a/components/core/buttons/TextButton.vue
+++ b/components/core/buttons/TextButton.vue
@@ -1,9 +1,14 @@
 <template>
-    <button :class="coreButtonClasses">
-        <ext-link v-if="href" :href="href">
+    <button>
+        <ext-link v-if="href" :href="href" :class="coreButtonClasses">
             <slot></slot>
         </ext-link>
-        <locale-link v-else-if="to" :to="to" customized>
+        <locale-link
+            v-else-if="to"
+            :to="to"
+            customized
+            :class="coreButtonClasses"
+        >
             <slot></slot>
         </locale-link>
         <slot v-else></slot>


### PR DESCRIPTION
## Types of Changes

**Thanks for sending a pull request! Please fill in the following content to let us know better about this change.**
Please put an `x` in the box that applies.

- [x] **Bugfix**
- [ ] **New feature**
- [ ] **Refactoring**
- [ ] **Breaking change** (any change that would cause existing functionality to not work as expected)
- [ ] **Documentation Update**
- [ ] **Other (please describe)**

## Description

move stylesheet's class from <button> tag to <a> tag

## Steps to Test This Pull Request

1. go to homepage index and click on sponsor us & be a sponsor

## Expected Behavior

1. It only worked for clicking on words("sponsor us"/"be a sponsor") to go to the sponsor page before, but now it works for the whole button.

## Related Issue

1. Not sure if this is the best way to fix this.
