### PR TITLE
chore: follow Python syntax for slogan

### DIFF
--- a/components/landing-focus/LandingFocusSlogan.vue
+++ b/components/landing-focus/LandingFocusSlogan.vue
@@ -2,8 +2,8 @@
     <div class="flex items-center">
         <pre
             class="text-xs mr-4"
-        ><code>with</code> Pythonistas() <code>as</code> us:
-          Python.TW.reunion()</pre>
+        ><code>with</code> Pythonistas() <code>as</code> us:<br>  Python.TW.reunion()
+        </pre>
         <div class="w-10 md:w-16 lg:w-20">
             <img
                 src="~/static/page-home-slogan.png"


### PR DESCRIPTION
## Types of Changes

- [ ] **Bugfix**
- [ ] **New feature**
- [ ] **Refactoring**
- [ ] **Breaking change**
- [ ] **Documentation Update**
- [x] **Other (fix indentation of slogan)**

## Description

The indent of the current slogan on the index page does not follow the Python syntax, which makes Pythonistas uncomfortable. 

![image](https://user-images.githubusercontent.com/24987826/119028822-7f9df700-b9da-11eb-8581-5570017836b8.png)

Use 2 spaces instead.

![image](https://user-images.githubusercontent.com/24987826/119028899-90e70380-b9da-11eb-9b31-2e5803ed6eb8.png)


## Steps to Test This Pull Request

1. Open the index page & show the slogan to someone who codes in Python. They are ought to complain about the indentation.

## Expected Behavior

After the change, Python coders are expected to believe it's a great slogan.

## More Information

What about the errors from the linter?
