### PR TITLE
style: update tab colors

### DIFF
--- a/components/core/tabs/Tabs.vue
+++ b/components/core/tabs/Tabs.vue
@@ -64,10 +64,9 @@ export default {
 }
 
 .tab {
-    @apply inline-block text-xs md:text-sm rounded-2xl min-w-full border-2;
+    @apply inline-block text-xs md:text-sm rounded-2xl min-w-full border-2 bg-opacity-0;
     line-height: 29px;
-    color: #282828;
-    background: #e6ba17;
+    color: #c7c7c7;
     border-color: #c2a53a;
     box-shadow: 6px 6px 0 #c2a53a;
     padding: 20px;

--- a/pages/conference/keynotes.vue
+++ b/pages/conference/keynotes.vue
@@ -195,6 +195,7 @@ export default {
 
 .keynote__extLink {
     @apply font-bold;
+    color: #e6ba17;
 }
 
 .keynote__extLink:hover {


### PR DESCRIPTION
## Types of Changes

- [ ] **Bugfix**
- [ ] **New feature**
- [ ] **Refactoring**
- [ ] **Breaking change** (any change that would cause existing functionality to not work as expected)
- [ ] **Documentation Update**
- [x] **Other (style update)**

## Description

The style of the tab component has changed:

Current Design:

![image](https://user-images.githubusercontent.com/24987826/124397032-e0da1980-dd3f-11eb-91f5-820b65794177.png)


New Design:

![image](https://user-images.githubusercontent.com/24987826/124397020-c9029580-dd3f-11eb-950f-ccd6bf492528.png)
