### PR TITLE
style: fix prospectus page 

### DIFF
--- a/pages/sponsor/prospectus.vue
+++ b/pages/sponsor/prospectus.vue
@@ -530,7 +530,7 @@ export default {
     @apply text-center;
 }
 ul.list-disc {
-    @apply pl-0;
+    padding-left: 0 !important;
 }
 .ml-2vw {
     margin-left: 2vw;


### PR DESCRIPTION
## Types of Changes

**Thanks for sending a pull request! Please fill in the following content to let us know better about this change.**
Please put an `x` in the box that applies.

- [x] **Bugfix**
- [ ] **New feature**
- [ ] **Refactoring**
- [ ] **Breaking change** (any change that would cause existing functionality to not work as expected)
- [ ] **Documentation Update**
- [ ] **Other (please describe)**

## Description

Fix the sponsor package levels gird layout.

## Steps to Test This Pull Request

Steps to reproduce the behavior:
1. Run dev server and json server
2. Go to sponsor page
3. Click prospectus link
4. Check grid styles

## Expected Behavior

Right style without padding left in sponsor package levels section

## More Information

**Screenshots**
<img width="1520" alt="截圖 2021-07-22 下午7 13 37" src="https://user-images.githubusercontent.com/13831865/126630577-d33ea5f6-f5f2-4eff-a534-ec51400f263f.png">

