### PR TITLE
fix 2021 english title typo on history page

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,42 +1,31 @@
-## Types of Changes
+<!--(Thanks for sending a pull request! Please fill in the following content to let us know better about this change.)-->
 
-**Thanks for sending a pull request! Please fill in the following content to let us know better about this change.**
-Please put an `x` in the box that applies.
+## Types of changes
+<!--Please remove the types that does not apply to this change-->
 
-- [ ] **Bugfix**
-- [ ] **New feature**
-- [ ] **Refactoring**
-- [ ] **Breaking change** (any change that would cause existing functionality to not work as expected)
-- [ ] **Documentation Update**
-- [ ] **Other (please describe)**
+* **Bugfix**
+* **New feature**
+* **Refactoring**
+* **Breaking change** (any change that would cause existing functionality to not work as expected)
+* **Documentation Update**
+* **Other (please describe)**
 
 ## Description
-
-**Describe what the change is**
-You don't need to explain HOW you change the code. Your code, including comments in the code should explicitly
-self-describe enough about how you change the code.
+<!--Describe what the change is**-->
 
 ## Steps to Test This Pull Request
-
+<!--
 Steps to reproduce the behavior:
-1. Go to '...'
-2. Click on '...'
-3. Scroll down to '...'
-4. See error
+1. ...
+2. ...
+3. ...
+-->
 
-## Expected Behavior
-
-A clear and concise description of what you expected to happen.
+## Expected behavior
+<!--A clear and concise description of what you expected to happen-->
 
 ## Related Issue
+<!--If applicable, reference to the issue related to this pull request.-->
 
-If applicable, reference to the issue related to this pull request.
-
-## More Information
-
-**Screenshots**
-If applicable, add screenshots to help explain your problem.
-
-**Additional context**
-Add any other context about the problem here. You may also want to refer
-to [how to write the perfect pull request](https://github.blog/2015-01-21-how-to-write-the-perfect-pull-request/).
+## Additional context
+<!--Add any other context or screenshots about the pull request here.-->

--- a/i18n/about/history.i18n.js
+++ b/i18n/about/history.i18n.js
@@ -106,7 +106,7 @@ export default genI18nMessages({
                 'understand the unique culture of different communities.',
         },
         pycon2021: {
-            title: '2020「Reunion」',
+            title: '2021「Reunion」',
             content:
                 'This year is the 10th anniversary of PyCon Taiwan. ' +
                 'Due to COVID-19, we will be hosting our first ever online conference. ' +


### PR DESCRIPTION
## Types of Changes
- [x] **Bugfix**
- [x] **Documentation**

## Description
fix the typo in the following screenshot
![image](https://user-images.githubusercontent.com/5144808/127505305-fd931877-7d2c-4458-a111-472e92bc934f.png)

simplify github pull request template

## Steps to Test This Pull Request

## Expected Behavior
The second 2020 should now become 2021

## Related Issue

## More Information
