### PR TITLE
fix(footer): add color to word 'history'

### DIFF
--- a/components/core/footer/FooterHistory.vue
+++ b/components/core/footer/FooterHistory.vue
@@ -1,7 +1,7 @@
 <template>
     <div class="mt-10 mb-3">
         <div class="flex justify-center cursor-default">
-            <p class="py-3 font-bold">{{ $t('history') }}</p>
+            <p class="py-3 font-bold highlight">{{ $t('history') }}</p>
         </div>
         <div
             v-for="(count, index) in rowCount"
@@ -89,4 +89,8 @@ export default {
 }
 </script>
 
-<style scoped></style>
+<style scoped>
+.highlight {
+    color: #c2a53a;
+}
+</style>


### PR DESCRIPTION
<!--(Thanks for sending a pull request! Please fill in the following content to let us know better about this change.)-->

## Types of changes
<!--Please remove the types that does not apply to this change-->

* **Bugfix**

## Description

Add color #c2a53a to word 'history' on footer.

## Expected behavior
<!--A clear and concise description of what you expected to happen-->
<img width="159" alt="Screen Shot 2021-07-31 at 11 31 03 PM" src="https://user-images.githubusercontent.com/65331756/127744850-0c336eb5-6d64-4636-a010-68b50934c70b.png">

