### PR TITLE
fix: temporarily change youtube link to uuid

### DIFF
--- a/components/bulletins/BulletinCard.i18n.js
+++ b/components/bulletins/BulletinCard.i18n.js
@@ -32,7 +32,8 @@ export default genI18nMessages({
                     'Checkout all speeches on our channel. ' +
                     "Don't forget to subscribe!",
                 linkTitle: 'Subscribe',
-                linkHref: 'https://www.youtube.com/c/pycontaiwan',
+                linkHref:
+                    'https://www.youtube.com/channel/UCHLnNgRnfGYDzPCCH8qGbQw',
             },
             {
                 title: 'Epidemic Prevention',
@@ -80,7 +81,8 @@ export default genI18nMessages({
                 description:
                     'PyCon 也有 YouTube 頻道了！歡迎訂閱我們～每年都會固定整理議程的錄影讓大家能一同觀看。',
                 linkTitle: '線上訂閱',
-                linkHref: 'https://www.youtube.com/c/pycontaiwan',
+                linkHref:
+                    'https://www.youtube.com/channel/UCHLnNgRnfGYDzPCCH8qGbQw',
             },
             {
                 title: '防疫守則',

--- a/components/core/footer/FooterIcon.vue
+++ b/components/core/footer/FooterIcon.vue
@@ -63,7 +63,8 @@ export default {
                 },
                 {
                     src: require('~/static/img/footer/Youtube.svg'),
-                    link: 'https://www.youtube.com/PyConTaiwan',
+                    link:
+                        'https://www.youtube.com/channel/UCHLnNgRnfGYDzPCCH8qGbQw',
                     altName: 'Youtube Footer Icon',
                 },
                 {

--- a/layouts/default.vue
+++ b/layouts/default.vue
@@ -116,7 +116,7 @@ export default {
                             'https://www.facebook.com/pycontw/',
                             'https://twitter.com/PyConTW/',
                             'https://www.linkedin.com/company/pycontw',
-                            'https://www.youtube.com/PyConTaiwan',
+                            'https://www.youtube.com/channel/UCHLnNgRnfGYDzPCCH8qGbQw',
                             'https://instagram.com/pycontw/',
                             'https://github.com/pycontw/',
                             'https://pycontw.blogspot.com/',


### PR DESCRIPTION

## Types of changes
* **Bugfix**


## Description
* temporarily change youtube link to uuid
    * our customized link is temporraily disable and will be enabled again around early Sep

## Steps to Test This Pull Request
click the youtube link and it should be accessible after this fix

## Expected behavior
same above

## Related Issue
<!--If applicable, reference to the issue related to this pull request.-->

## Additional context
<!--Add any other context or screenshots about the pull request here.-->
