### PR TITLE
style: fix bulletin card based on design spec

### DIFF
--- a/components/bulletins/BulletinCard.i18n.js
+++ b/components/bulletins/BulletinCard.i18n.js
@@ -4,6 +4,14 @@ export default genI18nMessages({
     'en-us': {
         bulletins: [
             {
+                title: 'Hiring',
+                description:
+                    'The companies are here to recruit talents, hurry up! ' +
+                    "Yes, I'm talking to you! Come here, they NEED YOU!",
+                linkTitle: 'Go',
+                linkTo: '/events/jobs',
+            },
+            {
                 title: 'PyCast',
                 description:
                     'Checkout our brand new podcast channel, PyCast. ' +
@@ -55,6 +63,13 @@ export default genI18nMessages({
     },
     'zh-hant': {
         bulletins: [
+            {
+                title: '徵才資訊',
+                description:
+                    '厲害的公司都在這邊徵才還不趕快來看！對就是在說你！快點點進來這邊，他們 NEED YOU！',
+                linkTitle: '前往看看',
+                linkTo: '/events/jobs',
+            },
             {
                 title: 'PyCast',
                 description:

--- a/components/bulletins/BulletinCard.i18n.js
+++ b/components/bulletins/BulletinCard.i18n.js
@@ -88,7 +88,7 @@ export default genI18nMessages({
                 title: '防疫守則',
                 description:
                     '病毒退散！讓我們一同線上參與 PyCon TW 盛會，阻隔病毒傳播！',
-                linkTitle: '閱讀',
+                linkTitle: '前往閱讀',
                 linkTo: '/covid19_guidelines',
             },
             {

--- a/components/bulletins/BulletinCard.vue
+++ b/components/bulletins/BulletinCard.vue
@@ -10,6 +10,7 @@
                 :href="linkHref"
                 :to="linkTo"
                 secondary
+                bulletin
                 class="hidden md:block"
                 >{{ linkTitle }}</text-button
             >
@@ -55,12 +56,10 @@ export default {
 
 <style lang="postcss" scoped>
 .bulletinCard {
-    @apply relative flex flex-col items-center font-serif rounded-3xl;
-    border-width: 4px;
+    @apply relative flex flex-col items-center font-serif rounded-3xl border-4;
     width: 47%;
     @media (min-width: 415px) {
-        border-width: 3px;
-        width: 11rem;
+        width: 214px;
     }
     border-color: #4b4b4b;
     color: #4b4b4b;
@@ -84,7 +83,7 @@ export default {
 }
 
 .bulletinCard__content > h2 {
-    @apply text-base text-center mt-6 mb-5;
+    @apply text-base text-center mt-6 mb-5 font-bold;
     @media (min-width: 415px) {
         @apply text-xl mt-8 mb-5;
     }

--- a/components/bulletins/BulletinCardCollection.vue
+++ b/components/bulletins/BulletinCardCollection.vue
@@ -1,6 +1,12 @@
 <template>
     <div class="flex flex-col w-full">
-        <div class="bulletinCardCollection__cardContainer justify-center lg:justify-start">
+        <div
+            class="
+                bulletinCardCollection__cardContainer
+                justify-center
+                lg:justify-start
+            "
+        >
             <!-- <slot></slot> -->
             <bulletin-card
                 v-for="(bulletin, i) in $t('bulletins')"

--- a/components/bulletins/BulletinCardCollection.vue
+++ b/components/bulletins/BulletinCardCollection.vue
@@ -1,6 +1,6 @@
 <template>
     <div class="flex flex-col w-full">
-        <div class="bulletinCardCollection__cardContainer justify-start">
+        <div class="bulletinCardCollection__cardContainer justify-center lg:justify-start">
             <!-- <slot></slot> -->
             <bulletin-card
                 v-for="(bulletin, i) in $t('bulletins')"

--- a/components/core/buttons/TextButton.vue
+++ b/components/core/buttons/TextButton.vue
@@ -52,6 +52,10 @@ export default {
             type: String,
             default: undefined,
         },
+        bulletin: {
+            type: Boolean,
+            default: false,
+        },
     },
     computed: {
         coreButtonClasses() {
@@ -65,6 +69,7 @@ export default {
                 '--rounded': this.rounded,
                 '--block': this.block,
                 '--is-link': this.isLink,
+                '--bulletin': this.bulletin,
             }
         },
         medium() {
@@ -135,5 +140,10 @@ export default {
 .core-button.--is-link > a:hover {
     color: #7568f6;
     border-color: #7568f6;
+}
+
+.core-button.--medium.--bulletin:not(.--is-link),
+.core-button.--medium.--bulletin.--is-link > a {
+    border-width: 3px;
 }
 </style>

--- a/components/core/titles/H2.vue
+++ b/components/core/titles/H2.vue
@@ -1,14 +1,14 @@
 <template>
     <div class="flex justify-center">
-        <h2 :class="classObject">{{ subTitle }}</h2>
+        <h2 :class="classObject">{{ title }}</h2>
     </div>
 </template>
 
 <script>
 export default {
-    name: 'LandingH2',
+    name: 'CoreH2',
     props: {
-        subTitle: {
+        title: {
             type: String,
             required: true,
         },

--- a/components/core/titles/LandingH2.vue
+++ b/components/core/titles/LandingH2.vue
@@ -1,0 +1,40 @@
+<template>
+    <div class="flex justify-center">
+        <h2 :class="classObject">{{ subTitle }}</h2>
+    </div>
+</template>
+
+<script>
+export default {
+    name: 'LandingH2',
+    props: {
+        subTitle: {
+            type: String,
+            required: true,
+        },
+        bulletinColor: {
+            type: Boolean,
+            default: false,
+        },
+    },
+    computed: {
+        classObject() {
+            return {
+                'tracking-wider': this.$i18n.locale !== 'en-us',
+                'bulletin-color': this.bulletinColor,
+            }
+        },
+    },
+}
+</script>
+
+<style lang="postcss" scoped>
+h2 {
+    @apply mt-2 md:mt-10 mb-8 md:mb-16 text-2xl md:text-3xl;
+    @apply font-serif text-center font-bold;
+    color: #e6ba17;
+}
+.bulletin-color {
+    color: #f3cc39;
+}
+</style>

--- a/components/core/titles/index.js
+++ b/components/core/titles/index.js
@@ -1,3 +1,4 @@
 import CoreH1 from './H1'
+import LandingH2 from './LandingH2'
 
-export { CoreH1 }
+export { CoreH1, LandingH2 }

--- a/components/core/titles/index.js
+++ b/components/core/titles/index.js
@@ -1,4 +1,4 @@
 import CoreH1 from './H1'
-import LandingH2 from './LandingH2'
+import CoreH2 from './H2'
 
-export { CoreH1, LandingH2 }
+export { CoreH1, CoreH2 }

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -48,17 +48,16 @@
 
         <landing-img-swiper />
 
-        <i18n-page-wrapper
-            custom-x
-            custom-y
-            class="py-12 px-4 sm:px-10 md:px-12 lg:px-20 bg-blue-primary"
-        >
-            <h1 class="bulletin-title">{{ $t('bulletinList') }}</h1>
+        <div class="bulletin-section">
+            <landing-h2
+                :sub-title="$t('bulletinList')"
+                bulletin-color
+            ></landing-h2>
             <bulletin-card-collection></bulletin-card-collection>
-        </i18n-page-wrapper>
+        </div>
 
         <div class="intro-section">
-            <h2 class="intro-title">{{ $t('pyconIntro') }}</h2>
+            <landing-h2 :sub-title="$t('pyconIntro')"></landing-h2>
             <intro></intro>
         </div>
 
@@ -98,6 +97,7 @@
 import { mapState } from 'vuex'
 import i18n from '@/i18n/index.i18n'
 import I18nPageWrapper from '@/components/core/i18n/PageWrapper'
+import LandingH2 from '~/components/core/titles/LandingH2'
 // import TextButton from '~/components/core/buttons/TextButton'
 import {
     SponsorCardCollection,
@@ -126,6 +126,7 @@ export default {
         SponsorModal,
         Intro,
         BulletinCardCollection,
+        LandingH2,
     },
     data() {
         return {
@@ -200,22 +201,13 @@ export default {
     background-color: #121023;
 }
 
-.intro-section h2.intro-title {
-    @apply mt-8 mb-16 font-serif font-bold text-center text-3xl;
-    color: #e6ba17;
-    @media (max-width: 767px) {
-        @apply mt-2 mb-8 text-2xl;
-    }
-}
-
 .intro-section {
     @apply pt-8 pb-20;
     background-color: #16132a;
 }
 
-.bulletin-title {
-    @apply font-serif;
-    color: #f3cc39;
+.bulletin-section {
+    @apply py-12 px-4 sm:px-10 md:px-12 lg:px-20;
 }
 
 .sponsor-title {

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -49,15 +49,12 @@
         <landing-img-swiper />
 
         <div class="bulletin-section">
-            <landing-h2
-                :sub-title="$t('bulletinList')"
-                bulletin-color
-            ></landing-h2>
+            <core-h2 :title="$t('bulletinList')" bulletin-color></core-h2>
             <bulletin-card-collection></bulletin-card-collection>
         </div>
 
         <div class="intro-section">
-            <landing-h2 :sub-title="$t('pyconIntro')"></landing-h2>
+            <core-h2 :title="$t('pyconIntro')"></core-h2>
             <intro></intro>
         </div>
 
@@ -97,7 +94,7 @@
 import { mapState } from 'vuex'
 import i18n from '@/i18n/index.i18n'
 import I18nPageWrapper from '@/components/core/i18n/PageWrapper'
-import LandingH2 from '~/components/core/titles/LandingH2'
+import CoreH2 from '~/components/core/titles/H2'
 // import TextButton from '~/components/core/buttons/TextButton'
 import {
     SponsorCardCollection,
@@ -126,7 +123,7 @@ export default {
         SponsorModal,
         Intro,
         BulletinCardCollection,
-        LandingH2,
+        CoreH2,
     },
     data() {
         return {


### PR DESCRIPTION
<!--(Thanks for sending a pull request! Please fill in the following content to let us know better about this change.)-->

## Types of changes
<!--Please remove the types that do not apply to this change-->

* **Bugfix**

## Description
#### Fixed all problems(1st ~ 5th) which are mentioned in #127 .
1. Changed card width to 214px in `BulletinCard.vue` 
-> Solved `1st` in the issue's Expected Behavior.
2. Added `font-bold` in `BulletinCard.vue`.
-> Solved `4th` in the issue's Expected Behavior.
3. Changed「閱讀」to「前往閱讀」in `BulletinCard.i18n.js` .
-> Solved `5th` in the issue's Expected Behavior.
---
4. For `2nd` and `3rd` which are mentioned in the issue's Expected Behavior. (Design Team wanted the border-width to always be 4px on the cards, and to always be 3px on the button.). So,
    - I remained `border-4` in `BulletinCard.vue` to solve `2nd`.
    - Added `bulletin props` to solve `3rd`.
 -> Solved `2nd` & `3rd` in the issue's Expected Behavior.

## More Detail for this PR
1. On mobile view, `justify-start` caused the whole section isn't in the center position, I change it to `justify-center`. But since we need to have five-card in one row on the desktop view now, I still remained `lg:justify-start` which will be applied on Desktop view.
2. And also in this PR, I make `<LandingH2.vue>` components, for the subtitle of each section on the home page, to make it more structured and reasonable.

## Steps to Test This Pull Request
- Go to the home page's bulletin section.

<img src="https://user-images.githubusercontent.com/65331756/129818370-aeae3a29-22b5-488b-89a9-1628520fb6b5.png" width="50%">
<img width="80%" alt="Screen Shot 2021-08-18 at 8 39 53 AM" src="https://user-images.githubusercontent.com/65331756/129818555-0be47c33-ace2-49da-8c7c-1f79e4e4942b.png">

## Related Issue
Fixed #127 

