### PR TITLE
style: fix keynote font style based on design spec

### DIFF
--- a/components/core/tabs/Tabs.vue
+++ b/components/core/tabs/Tabs.vue
@@ -48,7 +48,7 @@ export default {
 }
 .tabs__headers > .header {
     @apply inline-block ml-1 py-2 px-2;
-    @apply text-sm text-center font-black;
+    @apply text-base text-center font-black;
     @apply border rounded-t-lg bg-transparent cursor-pointer;
     color: #e6ba17;
     border-color: #c2a53a;

--- a/components/core/tabs/Tabs.vue
+++ b/components/core/tabs/Tabs.vue
@@ -48,7 +48,7 @@ export default {
 }
 .tabs__headers > .header {
     @apply inline-block ml-1 py-2 px-2;
-    @apply text-base text-center font-black;
+    @apply text-sm md:text-base text-center font-black;
     @apply border rounded-t-lg bg-transparent cursor-pointer;
     color: #e6ba17;
     border-color: #c2a53a;

--- a/pages/conference/keynotes.vue
+++ b/pages/conference/keynotes.vue
@@ -179,12 +179,12 @@ export default {
 }
 
 .keynote__name {
-    @apply font-serif font-semibold text-sm text-center py-2;
+    @apply font-serif font-black text-base text-center py-2;
     color: #c2a53a;
 }
 
 .keynote__title {
-    @apply font-serif font-semibold text-sm text-center py-2;
+    @apply font-serif font-black text-base text-center py-2;
     color: #c2a53a;
 }
 


### PR DESCRIPTION
<!--(Thanks for sending a pull request! Please fill in the following content to let us know better about this change.)-->

## Types of changes
<!--Please remove the types that does not apply to this change-->

* **Bugfix**

## Description
- Fix keynote `font-size` and `font-weight` based on design spec.

## Steps to Test This Pull Request
- Go to the keynote page.

## Related Issue
#128 