### PR TITLE
fix(navBarItems): vue mistakenly recognize constant obj as component

### DIFF
--- a/components/core/header/nav-bar/NavBar.vue
+++ b/components/core/header/nav-bar/NavBar.vue
@@ -51,7 +51,7 @@
 </template>
 
 <script>
-import navBarItems from '@/components/core/header/nav-bar/nav-bar-items'
+import { navBarItems } from '@/components/core/header/nav-bar/nav-bar-items'
 import NavBarItemDropdown from './NavBarItemDropdown'
 import i18n from './NavBar.i18n'
 import ExtLink from '~/components/core/links/ExtLink'

--- a/components/core/header/nav-bar/NavBarHamburger.vue
+++ b/components/core/header/nav-bar/NavBarHamburger.vue
@@ -62,7 +62,7 @@
 import IconHamburgerMenuIcon from '@/components/core/icons/IconHamburgerMenuIcon'
 import NavBarItemAccordion from '@/components/core/header/nav-bar/NavBarItemAccordion'
 import ExtLink from '@/components/core/links/ExtLink'
-import navBarItems from './nav-bar-items'
+import { navBarItems } from './nav-bar-items'
 import i18n from './NavBar.i18n'
 
 export default {

--- a/components/core/header/nav-bar/nav-bar-items.js
+++ b/components/core/header/nav-bar/nav-bar-items.js
@@ -1,4 +1,4 @@
-export default Object.freeze({
+export const navBarItems = Object.freeze({
     conferenceItems: [
         {
             i18nKey: 'schedule',


### PR DESCRIPTION
<!--(Thanks for sending a pull request! Please fill in the following content to let us know better about this change.)-->

## Types of changes
<!--Please remove the types that does not apply to this change-->

* **Bugfix**

The newer version Vue mistakenly recognizes the constant obj in a separated javascript (`/components/core/header/nav-bar/nav-bar-items.js` in our case) as a component. The following error occurs when Vue initializes the components.

![image](https://user-images.githubusercontent.com/24987826/130218005-f359be4a-854f-454d-a01f-e6004835fce5.png)


Solution: export a constant in `nav-bar-items.js` rather a module, which makes Vue not to take it as a component.