### PR TITLE
chore: exclude js files to be initialized as components

### DIFF
--- a/components/core/header/nav-bar/NavBar.vue
+++ b/components/core/header/nav-bar/NavBar.vue
@@ -51,7 +51,7 @@
 </template>
 
 <script>
-import { navBarItems } from '@/components/core/header/nav-bar/nav-bar-items'
+import navBarItems from '@/components/core/header/nav-bar/nav-bar-items'
 import NavBarItemDropdown from './NavBarItemDropdown'
 import i18n from './NavBar.i18n'
 import ExtLink from '~/components/core/links/ExtLink'

--- a/components/core/header/nav-bar/NavBarHamburger.vue
+++ b/components/core/header/nav-bar/NavBarHamburger.vue
@@ -62,7 +62,7 @@
 import IconHamburgerMenuIcon from '@/components/core/icons/IconHamburgerMenuIcon'
 import NavBarItemAccordion from '@/components/core/header/nav-bar/NavBarItemAccordion'
 import ExtLink from '@/components/core/links/ExtLink'
-import { navBarItems } from './nav-bar-items'
+import navBarItems from './nav-bar-items'
 import i18n from './NavBar.i18n'
 
 export default {

--- a/components/core/header/nav-bar/nav-bar-items.js
+++ b/components/core/header/nav-bar/nav-bar-items.js
@@ -1,4 +1,4 @@
-export const navBarItems = Object.freeze({
+export default Object.freeze({
     conferenceItems: [
         {
             i18nKey: 'schedule',

--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -25,7 +25,7 @@ export default {
     ],
 
     // Auto import components (https://go.nuxtjs.dev/config-components)
-    components: true,
+    components: [{ path: '~/components/', extensions: ['vue'] }],
 
     // Modules for dev and build (recommended) (https://go.nuxtjs.dev/config-modules)
     buildModules: [


### PR DESCRIPTION
<!--(Thanks for sending a pull request! Please fill in the following content to let us know better about this change.)-->

## Types of changes
<!--Please remove the types that does not apply to this change-->

* **Refactoring**

## Description

We'll receive warnings when run the dev server:
![image](https://user-images.githubusercontent.com/24987826/130340117-43fb5e04-cc7b-4fd7-a58c-dd443f39c43d.png)


The root cause is [nuxt/components](https://github.com/nuxt/components) tries to render `js` files under `components` directory as component, which mistakenly regards those `js` files for exporting components in a module (e.g. `components/jobs/index.js`) as a component.

Update `nuxt.config.js` to only render `*.vue` files to suppress the reexport warning and also allow us reverting #146.