### PR TITLE
chore: maintain mock-server docker environment

### DIFF
--- a/mock-server.Dockerfile
+++ b/mock-server.Dockerfile
@@ -4,6 +4,6 @@ WORKDIR /usr/local
 
 RUN npm install -g json-server
 
-COPY db.json routes.json ./
+COPY db.json routes.json json-server-middlewares.js ./
 
 CMD ["json-server", "--watch", "db.json", "--routes", "routes.json", "--host", "0.0.0.0", "--port", "9876", "--middlewares", "json-server-middlewares.js"]


### PR DESCRIPTION
<!--(Thanks for sending a pull request! Please fill in the following content to let us know better about this change.)-->

## Types of changes
<!--Please remove the types that do not apply to this change-->

* **Bugfix**

## Description
- Updated docker environment set up to make mock-server work fine.

## Additional context
- I'm not sure why `json-server-middlewares.js` didn't configure in Dockerfile, maybe has another reason. 😅
