### PR TITLE
fix: add scrollToHash behavior when navigating from schedule to keynotes page

### DIFF
--- a/components/schedule/ScheduleEvent.vue
+++ b/components/schedule/ScheduleEvent.vue
@@ -96,10 +96,14 @@ export default {
             }
         },
         eventPagePath() {
-            const { event_type: eventType, event_id: eventId } = this.value
+            const {
+                event_type: eventType,
+                event_id: eventId,
+                speakers,
+            } = this.value
             if (eventType === 'keynote') {
-                // TODO: navigate to specific anchor (hash)
-                return '/conference/keynotes/'
+                const keynoteSpeakerId = speakers[0].split(' ').join('_')
+                return `/conference/keynotes#${keynoteSpeakerId}`
             } else if (['talk', 'tutorial', 'sponsored'].includes(eventType)) {
                 return `/conference/${eventType}/${eventId}/`
             }

--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -9,6 +9,42 @@ export default {
     // Re-route for GitHub Pages to serve with /assets
     router: {
         base: process.env.ROUTER_BASE || DEFAULT_ROUTER_BASE,
+        // scroll behavior config for scroll to hash
+        // https://nuxtjs.org/docs/2.x/configuration-glossary/configuration-router#scrollbehavior
+        // https://stackoverflow.com/questions/60952725/anchor-in-nuxt-component-not-working-on-same-page-the-anchor-is-included-on
+        async scrollBehavior(to, from, savedPosition) {
+            if (savedPosition) {
+                return savedPosition
+            }
+
+            const findEl = (hash, x = 0) => {
+                return (
+                    document.querySelector(hash) ||
+                    new Promise((resolve) => {
+                        if (x > 50) {
+                            return resolve(document.querySelector('#app'))
+                        }
+                        setTimeout(() => {
+                            resolve(findEl(hash, ++x || 1))
+                        }, 100)
+                    })
+                )
+            }
+
+            if (to.hash) {
+                const el = await findEl(to.hash)
+                if ('scrollBehavior' in document.documentElement.style) {
+                    return window.scrollTo({
+                        top: el.offsetTop,
+                        behavior: 'smooth',
+                    })
+                } else {
+                    return window.scrollTo(0, el.offsetTop)
+                }
+            }
+
+            return { x: 0, y: 0 }
+        },
     },
     // Global page headers (https://go.nuxtjs.dev/config-head)
     // Move to layout/default.vue due to gtm-module not support head function (https://github.com/nuxt-community/gtm-module/issues/56)

--- a/pages/conference/keynotes.vue
+++ b/pages/conference/keynotes.vue
@@ -2,7 +2,11 @@
     <i18n-page-wrapper class="px-8 sm:px-10 md:px-32 lg:px-60" custom-x>
         <core-h1 :title="$t('title')"></core-h1>
         <i18n path="intro" tag="p" class="intro"></i18n>
-        <div v-for="keynote in keynotesData" :key="keynote.id">
+        <div
+            v-for="keynote in keynotesData"
+            :id="getKeynoteId(keynote)"
+            :key="keynote.id"
+        >
             <div class="keynote__photo">
                 <img
                     :src="keynote.speaker.photo"
@@ -132,6 +136,9 @@ export default {
         }))
     },
     methods: {
+        getKeynoteId(keynote) {
+            return keynote.speaker.name_en_us.split(' ').join('_')
+        },
         getAttributeByLocale(data, attr) {
             const localeMap = { 'en-us': 'en_us', 'zh-hant': 'zh_hant' }
             const attributeName = `${attr}_${localeMap[this.$i18n.locale]}`


### PR DESCRIPTION
<!--(Thanks for sending a pull request! Please fill in the following content to let us know better about this change.)-->

## Types of changes
<!--Please remove the types that does not apply to this change-->

* **Bugfix**

## Description
<!--Describe what the change is**-->
Navigate and scroll to corresponding speaker on keynote page when user clicks on schedule.


https://user-images.githubusercontent.com/13831865/130480148-c28498bc-cd8d-4c2d-aa21-4f5aa1bf9f25.mov


