### PR TITLE
chore: smaller job cards

### DIFF
--- a/components/jobs/JobsCard.vue
+++ b/components/jobs/JobsCard.vue
@@ -20,9 +20,9 @@ export default {
                 'h-20': true,
                 'm-1': true,
                 'cursor-pointer': !this.active,
-                'md:w-40': true,
-                'md:h-32': true,
-                'md:m-3': true,
+                'md:w-24': true,
+                'md:h-20': true,
+                'md:m-2': true,
                 '-active': this.active,
             }
         },
@@ -35,7 +35,7 @@ export default {
 }
 </script>
 
-<style scoped>
+<style lang="postcss" scoped>
 .jobsCard {
     @apply flex bg-white rounded-2xl;
     opacity: 0.2;

--- a/components/jobs/JobsCardCollection.vue
+++ b/components/jobs/JobsCardCollection.vue
@@ -14,6 +14,6 @@ export default {
 .jobsCardCollection {
     @apply sticky z-50 flex w-full px-0 py-4 flex-wrap justify-center items-center;
     top: 48px;
-    background-color: #212121;
+    background-color: #121023;
 }
 </style>


### PR DESCRIPTION
<!--(Thanks for sending a pull request! Please fill in the following content to let us know better about this change.)-->

## Types of changes
<!--Please remove the types that does not apply to this change-->

* **Bugfix**

## Description

The sponsor card on job listing page is too large, which makes the description section is too small on certain devices. See the [discord discussion](https://discord.com/channels/752904426057892052/755828862054695125/885208238583316622) for detail.

![image](https://user-images.githubusercontent.com/24987826/132559450-b58935c8-2979-4c50-929a-3fa3c6fbcdef.png)

Update the card size to design spec (120x100) to ease this issue.
![image](https://user-images.githubusercontent.com/24987826/132559777-b46bc426-dfed-40d0-93e2-4b7e12acb721.png)
