### PR TITLE
fix: slido tab displaying issue

### DIFF
--- a/components/core/tabs/Tabs.vue
+++ b/components/core/tabs/Tabs.vue
@@ -27,6 +27,9 @@ export default {
     },
     mounted() {
         this.selectTab(0)
+        this.$root.$on('initTabs', () => {
+            this.selectTab(0)
+        })
     },
     methods: {
         selectTab(i) {

--- a/pages/conference/_eventType/_id.vue
+++ b/pages/conference/_eventType/_id.vue
@@ -144,16 +144,12 @@
                     </div>
                 </div>
             </tab>
-            <!--
-            TODO: This tab is commented out due to an unresolve issue that
-            this tab is displayed with the first tab after rendering.
-            -->
-            <!-- <tab v-if="!!data.slido_embed_link" title="Slido">
+            <tab v-if="!!data.slido_embed_link" title="Slido">
                 <iframe
                     class="speech__slido"
                     :src="data.slido_embed_link"
                 ></iframe>
-            </tab> -->
+            </tab>
         </tabs>
     </i18n-page-wrapper>
 </template>
@@ -217,7 +213,8 @@ export default {
             eventType: this.$route.params.eventType,
             eventId: this.$route.params.id,
         })
-        this.processData()
+        await this.processData()
+        this.$root.$emit('initTabs')
     },
     methods: {
         processData() {


### PR DESCRIPTION

<!--(Thanks for sending a pull request! Please fill in the following content to let us know better about this change.)-->

## Types of changes
<!--Please remove the types that does not apply to this change-->

* **Bugfix**

## Description

[WHY]
The visibility of Tab component is simultaneously controlled by Tabs component & speech detail page, which causes the slido tab is always shown after component init.

[HOW]
Create a new event listener for selecting the first tab and trigger the event after component initialization in speech detail page.