### PR TITLE
feat: add job listing page for gather town layout

### DIFF
--- a/components/jobs/JobsCardCollection.vue
+++ b/components/jobs/JobsCardCollection.vue
@@ -1,5 +1,5 @@
 <template>
-    <div class="jobsCardCollection">
+    <div :class="jobsCardCollection">
         <slot></slot>
     </div>
 </template>
@@ -7,13 +7,42 @@
 <script>
 export default {
     name: 'JobsCardCollection',
+    props: {
+        site: {
+            type: Boolean,
+            default: false,
+        },
+        gather: {
+            type: Boolean,
+            default: false,
+        },
+    },
+    computed: {
+        jobsCardCollection() {
+            return {
+                'core-jobsCardCollection': true,
+                '--site': this.site,
+                '--gather': this.gather,
+            }
+        },
+    },
 }
 </script>
 
 <style scoped>
-.jobsCardCollection {
-    @apply sticky z-50 flex w-full px-0 py-4 flex-wrap justify-center items-center;
-    top: 48px;
+.core-jobsCardCollection {
+    @apply flex px-0;
     background-color: #121023;
+}
+
+.core-jobsCardCollection.--site {
+    @apply z-50 py-4 sticky w-full;
+    @apply flex-wrap items-center justify-center;
+    top: 48px;
+}
+
+.core-jobsCardCollection.--gather {
+    @apply sm:px-4 md:pr-4 md:pl-16;
+    @apply flex-col justify-start pt-8 md:pt-7;
 }
 </style>

--- a/pages/events/jobs-gather.vue
+++ b/pages/events/jobs-gather.vue
@@ -1,24 +1,30 @@
 <template>
     <div>
         <core-h1 :title="$t('title')" class="mt-24"></core-h1>
-        <jobs-card-collection ref="jobsCardCollection" site>
-            <jobs-card
-                v-for="sponsor in jobsData"
-                :key="sponsor.id"
-                :sponsor-name="sponsor.sponsor_name"
-                :logo-url="sponsor.sponsor_logo_url"
-                :active="selectedSponsor.id === sponsor.id"
-                @click="setSelectedSponsor(sponsor)"
-            ></jobs-card>
-        </jobs-card-collection>
-        <i18n-page-wrapper class="pt-8 pb-12" custom-y>
-            <jobs-panel
-                ref="jobsPanel"
-                :jobs="selectedSponsor.jobs"
-                :cta-label="$t('applyNow')"
-                :empty-message="$t('noJobs')"
-            ></jobs-panel>
-        </i18n-page-wrapper>
+        <div class="flex flex-row">
+            <jobs-card-collection ref="jobsCardCollection" gather>
+                <jobs-card
+                    v-for="sponsor in jobsData"
+                    :key="sponsor.id"
+                    :sponsor-name="sponsor.sponsor_name"
+                    :logo-url="sponsor.sponsor_logo_url"
+                    :active="selectedSponsor.id === sponsor.id"
+                    @click="setSelectedSponsor(sponsor)"
+                ></jobs-card>
+            </jobs-card-collection>
+            <i18n-page-wrapper
+                class="pt-8 pb-12 px-0 sm:px-4 md:pr-8 md:pl-4"
+                custom-y
+                custom-x
+            >
+                <jobs-panel
+                    ref="jobsPanel"
+                    :jobs="selectedSponsor.jobs"
+                    :cta-label="$t('applyNow')"
+                    :empty-message="$t('noJobs')"
+                ></jobs-panel>
+            </i18n-page-wrapper>
+        </div>
     </div>
 </template>
 

--- a/pages/events/jobs-gather.vue
+++ b/pages/events/jobs-gather.vue
@@ -1,6 +1,6 @@
 <template>
     <div>
-        <core-h1 :title="$t('title')" class="mt-24"></core-h1>
+        <core-h1 :title="$t('title')" class="mt-12 mb-0"></core-h1>
         <div class="flex flex-row">
             <jobs-card-collection ref="jobsCardCollection" gather>
                 <jobs-card
@@ -13,7 +13,7 @@
                 ></jobs-card>
             </jobs-card-collection>
             <i18n-page-wrapper
-                class="pt-8 pb-12 px-0 sm:px-4 md:pr-8 md:pl-4"
+                class="pt-0 pb-12 px-0 sm:px-4 md:pr-8 md:pl-4"
                 custom-y
                 custom-x
             >


### PR DESCRIPTION
<!--(Thanks for sending a pull request! Please fill in the following content to let us know better about this change.)-->

## Types of changes
<!--Please remove the types that do not apply to this change-->
* **New feature**

## Description
- Add a job listing page for Gather Town's layout.
- The route for this page is `/events/jobs-gather`. 
(The original job listing page for the website is `/events/jobs`.)

## Steps to Test This Pull Request
Steps to reproduce the behavior:
1. Go to [http://ocalhost:3000/2021/en-us/events/jobs-gather](http://localhost:3000/2021/en-us/events/jobs-gather)
2. And you can check this page.

## Expected behavior
- It should look like the screenshots below:

<details>
<summary>zh-hant</summary>
<img src="https://user-images.githubusercontent.com/65331756/133784090-78380f79-27f2-4da5-93a6-7c273ed012c3.jpeg" />
<img src="https://user-images.githubusercontent.com/65331756/133784148-79958b4c-f95e-4d6f-8ea8-8d0731e21f43.jpeg" width="50%"/>
</details>

<details>
<summary>en-us</summary>
<img src="https://user-images.githubusercontent.com/65331756/133783641-42e9f44d-01f4-4890-a243-25bfe3eed485.jpeg" />
<img src="https://user-images.githubusercontent.com/65331756/133783356-73621157-e07e-4e8a-aa57-ab8077c4d14d.jpeg" width="50%"/>
</details>

## Additional context
After having a discussion with Matt, A specific CSS style(`size`, `padding`, `margin`....) in mobile view will not be considered.
