### PR TITLE
fix(ext): Fix wrong rendering when giving correct token

### DIFF
--- a/i18n/ext/discord.i18n.js
+++ b/i18n/ext/discord.i18n.js
@@ -11,7 +11,6 @@ export default genI18nMessages({
         stepOne: '1. Register',
         stepOneDescription:
             'Users can find a #registration-desk channel under PYCON TW 2021 category. There is a PyCon TW RegBot in this channel to help you register to your roles.',
-        token: '[TOKEN]',
         registerAction: {
             action: 'Enter !register {token} in this channel to register',
             note: '(If you want to get your own Token, please click the link in the letter.)',
@@ -186,7 +185,7 @@ export default genI18nMessages({
         },
         og: {
             title: 'PyCon TW Discord Guideline',
-            pageAbstract:
+            description:
                 'If you have not installed Discord or joined Python Taiwan Discord server, follow Setting up Discord and setup your Discord first.',
         },
     },
@@ -200,7 +199,6 @@ export default genI18nMessages({
         stepOne: '1. 註冊',
         stepOneDescription:
             '使用者會看到在 PYCON TW 2021 的類別下會有一個 #registration-desk 頻道。在此頻道會有一個 PyCon TW RegBot 負責註冊使用者到對應身分組。',
-        token: '[TOKEN]',
         registerAction: {
             action: '輸入 !register {token} 以進行註冊',
             note: '(如要取得您的專屬 Token 請點擊行前信中的連結)',
@@ -369,10 +367,10 @@ export default genI18nMessages({
                 '複製上面的邀請連結，並把它貼到對話方塊中，接著按下加入即可。',
             ],
         },
-    },
-    og: {
-        title: 'PyCon TW Discord 指南',
-        description:
-            '如果尚未安裝 Discord 並加入 Python Taiwan 的伺服器，請先閱讀 設定 Discord 與加入 Python Taiwan 伺服器',
+        og: {
+            title: 'PyCon TW Discord 指南',
+            description:
+                '如果尚未安裝 Discord 並加入 Python Taiwan 的伺服器，請先閱讀 設定 Discord 與加入 Python Taiwan 伺服器',
+        },
     },
 })

--- a/pages/ext/discord.vue
+++ b/pages/ext/discord.vue
@@ -14,9 +14,8 @@
                 </p>
             </template>
         </banner>
-        <I18nPageWrapper class="pt-8 px-8 md:px-57 lg:px-56">
-            <div v-if="!isValidAttendee">{{ $t('invalidAttendee') }}</div>
-            <div v-else>
+        <i18n-page-wrapper class="pt-8 px-8 md:px-57 lg:px-56">
+            <div>
                 <div class="section">
                     <core-h1 :title="$t('tutorialsHeader')"></core-h1>
                     <p class="paragraph-title font-bold text-base md:text-lg">
@@ -32,9 +31,7 @@
                         class="bold-title"
                     >
                         <template #token>
-                            <span v-if="!isValidAttendee">{{
-                                $t('token')
-                            }}</span>
+                            <span v-if="!isValidAttendee">[TOKEN]</span>
                             <span v-else>{{ token }}</span>
                         </template>
                     </i18n>
@@ -187,7 +184,7 @@
                     />
                 </div>
             </div>
-        </I18nPageWrapper>
+        </i18n-page-wrapper>
     </div>
 </template>
 
@@ -211,17 +208,18 @@ export default {
         Banner,
         ExtLink,
     },
-    async asyncData({ store, query }) {
-        const token = query.token
-        await store.dispatch('$verifyAttendee', { token })
-        return {
-            token,
-            isValidAttendee:
-                store.state.youtubeInfo && store.state.youtubeInfo.length !== 0,
-        }
+    fetchOnServer: false,
+    async fetch() {
+        this.token = this.$nuxt.context.query.token
+        const store = this.$nuxt.context.store
+        await store.dispatch('$verifyAttendee', { token: this.token })
+        this.isValidAttendee =
+            store.state.youtubeInfo && store.state.youtubeInfo.length !== 0
     },
     data() {
         return {
+            isValidAttendee: false,
+            token: '[TOKEN]',
             aboutBanner: AboutBanner,
             discordIntro0,
             discordIntro1,

--- a/pages/ext/discord.vue
+++ b/pages/ext/discord.vue
@@ -214,7 +214,11 @@ export default {
     async asyncData({ store, query }) {
         const token = query.token
         await store.dispatch('$verifyAttendee', { token })
-        return { token }
+        return {
+            token,
+            isValidAttendee:
+                store.state.youtubeInfo && store.state.youtubeInfo.length !== 0,
+        }
     },
     data() {
         return {
@@ -231,12 +235,6 @@ export default {
                 'background-repeat': 'no-repeat',
                 'background-position': 'center',
             }
-        },
-        isValidAttendee() {
-            return (
-                this.$store.state.youtubeInfo &&
-                this.$store.state.youtubeInfo.length !== 0
-            )
         },
     },
     head() {

--- a/pages/ext/live.vue
+++ b/pages/ext/live.vue
@@ -1,5 +1,5 @@
 <template>
-    <I18nPageWrapper>
+    <i18n-page-wrapper>
         <core-h1 :title="$t('title')"></core-h1>
         <div v-if="!isValidAttendee">{{ $t('invalidAttendee') }}</div>
         <div v-else>
@@ -8,7 +8,7 @@
                 <youtube :video-id="videoInfo.video_id"></youtube>
             </div>
         </div>
-    </I18nPageWrapper>
+    </i18n-page-wrapper>
 </template>
 
 <script>
@@ -25,13 +25,19 @@ export default {
         CoreH1,
         Youtube,
     },
-    async asyncData({ store, query }) {
-        const token = query.token
+    fetchOnServer: false,
+    async fetch() {
+        const token = this.$nuxt.context.query.token
+        const store = this.$nuxt.context.store
         await store.dispatch('$verifyAttendee', { token })
+        this.isValidAttendee =
+            store.state.youtubeInfo && store.state.youtubeInfo.length !== 0
+        this.youtubeInfo = store.state.youtubeInfo
+    },
+    data() {
         return {
-            isValidAttendee:
-                store.state.youtubeInfo && store.state.youtubeInfo.length !== 0,
-            youtubeInfo: store.state.youtubeInfo,
+            isValidAttendee: false,
+            youtubeInfo: [],
         }
     },
     head() {

--- a/pages/ext/live.vue
+++ b/pages/ext/live.vue
@@ -28,17 +28,11 @@ export default {
     async asyncData({ store, query }) {
         const token = query.token
         await store.dispatch('$verifyAttendee', { token })
-    },
-    computed: {
-        isValidAttendee() {
-            return (
-                this.$store.state.youtubeInfo &&
-                this.$store.state.youtubeInfo.length !== 0
-            )
-        },
-        youtubeInfo() {
-            return this.$store.state.youtubeInfo
-        },
+        return {
+            isValidAttendee:
+                store.state.youtubeInfo && store.state.youtubeInfo.length !== 0,
+            youtubeInfo: store.state.youtubeInfo,
+        }
     },
     head() {
         return {


### PR DESCRIPTION
<!--(Thanks for sending a pull request! Please fill in the following content to let us know better about this change.)-->

## Types of changes
<!--Please remove the types that does not apply to this change-->

* **Bugfix**

## Description
Fix wrong rendering result in `ext/live` and `ext/discord` when giving correct token

## Steps to Test This Pull Request
Go to '{host}/pycontw-2021/en-us/ext/live?token={your_token}' or '{host}/pycontw-2021/en-us/ext/discord?token={your_token}'

## Expected behavior
<!--A clear and concise description of what you expected to happen-->
- if the token is valid: 
![localhost_3000_pycontw-2021_zh-hant_ext_live_token=matt_test_1234](https://user-images.githubusercontent.com/18432820/127292523-a4243431-36b2-4d9e-bceb-3f4aeec1a5bd.png)
- if the token is invalid:
![localhost_3000_pycontw-2021_en-us_ext_live_token=matt_test_123](https://user-images.githubusercontent.com/18432820/127292642-0add2d33-b3e1-4100-a52f-8aa14a08564c.png)


## Related Issue
<!--If applicable, reference to the issue related to this pull request.-->

## Additional context
<!--Add any other context or screenshots about the pull request here.-->
