### PR TITLE
fix(vue-meta): fix meta tags for reactivity

### DIFF
--- a/pages/conference/_eventType/_id.vue
+++ b/pages/conference/_eventType/_id.vue
@@ -178,6 +178,14 @@ export default {
         Youtube,
         MarkdownRenderer,
     },
+    async fetch() {
+        await this.$store.dispatch('$getSpeechData', {
+            eventType: this.$route.params.eventType,
+            eventId: this.$route.params.id,
+        })
+        await this.processData()
+        this.$root.$emit('initTabs')
+    },
     data() {
         return {
             data: {
@@ -206,14 +214,6 @@ export default {
     },
     computed: {
         ...mapState(['speechData']),
-    },
-    async created() {
-        await this.$store.dispatch('$getSpeechData', {
-            eventType: this.$route.params.eventType,
-            eventId: this.$route.params.id,
-        })
-        await this.processData()
-        this.$root.$emit('initTabs')
     },
     methods: {
         processData() {
@@ -251,7 +251,6 @@ export default {
             const minute = ('0' + datetime.getMinutes()).slice(-2)
             return `${hour}:${minute}`
         },
-        // FIXME: cannot successfully insert the correct value into head()
         metaInfo() {
             return {
                 title: this.data.title,
@@ -275,9 +274,9 @@ export default {
             }
         },
     },
-    // head() {
-    //     return this.metaInfo()
-    // },
+    head() {
+        return this.metaInfo()
+    },
 }
 </script>
 

--- a/pages/conference/_eventType/_id.vue
+++ b/pages/conference/_eventType/_id.vue
@@ -38,9 +38,8 @@
                         class="icon"
                         alt="icon-datetime"
                     />
-                    {{ $t(data.dateTag) }} • {{ getTime(data.begin_time) }}-{{
-                        getTime(data.end_time)
-                    }}
+                    {{ $t(`terms.${data.dateTag}`) }} •
+                    {{ getTime(data.begin_time) }}-{{ getTime(data.end_time) }}
                 </div>
                 <div class="speech__info">
                     <img :src="icons.level" class="icon" alt="icon-level" />


### PR DESCRIPTION
<!--(Thanks for sending a pull request! Please fill in the following content to let us know better about this change.)-->

## Types of changes
<!--Please remove the types that does not apply to this change-->

* **Bugfix**

## Description

### Status Quo

In the page component `pages/conference/_eventType/_id.vue`, the `og:title` and `og:description` won't act properly.

### Root Cause

The reason why they don't work is that the fields of meta tags, `og:title` and `og:description`, weren't updated after fetching data asynchronously for the dynamic page contents.

### Solution

Ensure that the async data is updated for the meta tags before the server sending rendered HTML to clients.

## Steps to Test This Pull Request

Steps to reproduce the behavior:

1. Navigate to the page of Conference -> Talks -> _[Any talk]_
2. Inspect elements and look at the `<head>` section of DOM
3. Refresh the search for `og:description` and paying attention to the `<title>` tag as well
4. See that `<title>` is the `<talk's title> | PyCon Taiwan 2021` and the `og:description` is the abstract of the talk without transitioning from the default title and `og:description`

## Expected behavior

Copy and paste the public URL should render the coherent contents

## Related Issue

_N/A_

## Additional context
<img width="731" alt="image" src="https://user-images.githubusercontent.com/7352613/134722329-d975d20c-1977-4980-9343-e4e57cfedc9e.png">
